### PR TITLE
IWA/PKI support and code cleanup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,7 @@ module.exports = function (grunt) {
                 files: {
                     'src/js/main.min.js': 'src/js/main.js',
                     'src/js/portal/portal.min.js': 'src/js/portal/portal.js',
+                    'src/js/portal/info.min.js': 'src/js/portal/info.js',
                     'src/js/portal/util.min.js': 'src/js/portal/util.js'
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ago-assistant",
   "title": "ArcGIS Online Assistant",
   "description": "A swiss army knife for your ArcGIS Online and Portal for ArcGIS accounts.x",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "author": "Evan Caldwell",
   "homepage": "https://github.com/Esri/ago-assistant",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ago-assistant",
   "title": "ArcGIS Online Assistant",
   "description": "A swiss army knife for your ArcGIS Online and Portal for ArcGIS accounts.x",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "author": "Evan Caldwell",
   "homepage": "https://github.com/Esri/ago-assistant",
   "repository": {

--- a/src/index.html
+++ b/src/index.html
@@ -109,7 +109,10 @@
                             <ul>
                                 <li>
                                     Copy content between accounts (even on different organizations or Portals)
-                                    <p align="middle"><em>Files and Hosted Feature Services cannot be copied at this time.</em></p>
+                                    <ul>
+                                        <li><em>Files cannot be copied at this time.</em></li>
+                                        <li><em>Copying hosted feature services adds a reference to the original service in the destination portal. Deep copying is planned for a future release.</em></li>
+                                    </ul>
                                 </li>
                                 <li>Inspect content</li>
                                 <li>Update the URLs for services in a Web Map</li>

--- a/src/index.html
+++ b/src/index.html
@@ -267,9 +267,7 @@
                     {name: "nprogress", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/lib", main: "nprogress-0.1.6"},
                     {name: "cal-heatmap", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/lib", main: "cal-heatmap-3.5.0.min"},
                     {name: "highlight", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/lib", main: "highlight-8.3.min"},
-                    {name: "portal", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal", main: "portal"},
-                    {name: "util", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal", main: "util"},
-                    {name: "info", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal", main: "info"}
+                    {name: "portal", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal"}
                 ],
             };
         </script>

--- a/src/index.html
+++ b/src/index.html
@@ -75,7 +75,7 @@
                 <h2>ArcGIS Online Assistant</h2>
                 <p class="lead">A swiss army knife for your ArcGIS Online and Portal for ArcGIS accounts.</p>
                 <p><a class="btn btn-lg btn-success" role="button" data-action="login" disabled="disabled">Log in to get started</a></p>
-                <p><a class="portal-signin" href="#portalLoginModal" data-toggle="modal">
+                <p><a class="portal-signin" data-toggle="modal">
                     Click here to log in to a Portal instance
                 </a></p>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -143,15 +143,19 @@
                         <div class="modal-body">
                             <form>
                                 <p>Enter the URL to your Portal</p>
-                                <div class="form-inline">
+                                <div class="form-horizontal">
                                     <div class="form-group">
-                                        <input class="form-control portalUrl" type="text" value="https://myportal.com/" id="portalUrl">
-                                    </div>
-                                    <div class="checkbox">
-                                        <label>
-                                            <input id="sourceWebTierAuth" type="checkbox">
-                                            Secured with PKI or IWA
-                                        </label>
+                                        <div class="col-md-6">
+                                            <input class="form-control portalUrl" type="text" value="https://myportal.com/" id="portalUrl">
+                                        </div>
+                                        <div class="col-md-6">
+                                            <div class="checkbox">
+                                                <label>
+                                                    <input id="sourceWebTierAuth" type="checkbox">
+                                                    Secured with PKI or IWA
+                                                </label>
+                                            </div>
+                                        </div>
                                     </div>
  
                                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -144,9 +144,10 @@
                             <form>
                                 <p>Enter the URL to your Portal</p>
                                 <div class="form-horizontal">
-                                    <div class="form-group">
+                                    <div class="form-group has-feedback">
                                         <div class="col-md-6">
                                             <input class="form-control portalUrl" type="text" value="https://myportal.com/" id="portalUrl">
+                                            <i class="glyphicon form-control-feedback" aria-hidden="true"></i>
                                         </div>
                                         <div class="col-md-6">
                                             <div class="checkbox">
@@ -205,9 +206,10 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <div class="form-group">
+                                        <div class="form-group has-feedback">
                                             <div class="col-md-6">
                                                 <input class="form-control portalUrl" type="text" value="https://www.arcgis.com/" id="destinationUrl">
+                                                <i class="glyphicon form-control-feedback" aria-hidden="true"></i>
                                             </div>
                                             <div class="col-md-6">
                                                 <div class="checkbox" id="destinationWebTierAuth">

--- a/src/index.html
+++ b/src/index.html
@@ -157,7 +157,6 @@
                                             </div>
                                         </div>
                                     </div>
- 
                                 </div>
                                 <br>
                                 <p>Enter your credentials:</p>
@@ -197,19 +196,27 @@
                                 <br>
                                 <form>
                                     <p>Select the destination:</p>
-                                    <div class="form-inline">
-                                        <div class="btn-group" data-toggle="buttons-radio">
-                                            <button type="button" id="destinationAgolBtn" class="btn btn-default active" data-toggle="button">ArcGIS Online</button>
-                                            <button type="button" id="destinationPortalBtn" class="btn btn-default" data-toggle="button">Portal for ArcGIS</button>
+                                    <div class="form-horizontal">
+                                        <div class="form-group">
+                                            <div class="col-md-6">
+                                                <div class="btn-group" data-toggle="buttons-radio">
+                                                    <button type="button" id="destinationAgolBtn" class="btn btn-default active" data-toggle="button">ArcGIS Online</button>
+                                                    <button type="button" id="destinationPortalBtn" class="btn btn-default" data-toggle="button">Portal for ArcGIS</button>
+                                                </div>
+                                            </div>
                                         </div>
                                         <div class="form-group">
-                                            <input class="form-control portalUrl" type="text" value="https://www.arcgis.com/" id="destinationUrl">
-                                        </div>
-                                        <div class="checkbox" id="destinationWebTierAuth">
-                                            <label>
-                                                <input id="destWebTierAuthChk" type="checkbox">
-                                                Secured with PKI or IWA
-                                            </label>
+                                            <div class="col-md-6">
+                                                <input class="form-control portalUrl" type="text" value="https://www.arcgis.com/" id="destinationUrl">
+                                            </div>
+                                            <div class="col-md-6">
+                                                <div class="checkbox" id="destinationWebTierAuth">
+                                                    <label>
+                                                        <input id="destWebTierAuthChk" type="checkbox">
+                                                        Secured with PKI or IWA
+                                                    </label>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <br>

--- a/src/index.html
+++ b/src/index.html
@@ -147,6 +147,13 @@
                                     <div class="form-group">
                                         <input class="form-control portalUrl" type="text" value="https://myportal.com/" id="portalUrl">
                                     </div>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input id="sourceWebTierAuth" type="checkbox">
+                                            Secured with PKI or IWA
+                                        </label>
+                                    </div>
+ 
                                 </div>
                                 <br>
                                 <p>Enter your credentials:</p>
@@ -193,6 +200,12 @@
                                         </div>
                                         <div class="form-group">
                                             <input class="form-control portalUrl" type="text" value="https://www.arcgis.com/" id="destinationUrl">
+                                        </div>
+                                        <div class="checkbox" id="destinationWebTierAuth">
+                                            <label>
+                                                <input id="destWebTierAuthChk" type="checkbox">
+                                                Secured with PKI or IWA
+                                            </label>
                                         </div>
                                     </div>
                                     <br>

--- a/src/index.html
+++ b/src/index.html
@@ -268,7 +268,8 @@
                     {name: "cal-heatmap", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/lib", main: "cal-heatmap-3.5.0.min"},
                     {name: "highlight", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/lib", main: "highlight-8.3.min"},
                     {name: "portal", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal", main: "portal"},
-                    {name: "util", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal", main: "util"}
+                    {name: "util", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal", main: "util"},
+                    {name: "info", location: location.pathname.replace(/\/[^/]*$/, '') + "/js/portal", main: "info"}
                 ],
             };
         </script>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -145,12 +145,14 @@ require([
                     startSession();
                 } else if (response.error.code === 400) {
                     var html = jquery("#loginErrorTemplate").html();
+                    jquery(".alert-danger.alert-dismissable").remove();
                     jquery("#portalLoginForm").before(html);
                 }
             })
             .fail(function (response) {
                 console.log(response.statusText);
                 var html = jquery("#loginErrorTemplate").html();
+                jquery(".alert-danger.alert-dismissable").remove();
                 jquery("#portalLoginForm").before(html);
             })
             .always(function () {
@@ -180,12 +182,14 @@ require([
                     });
                 } else if (response.error.code === 400) {
                     var html = jquery("#loginErrorTemplate").html();
+                    jquery(".alert-danger.alert-dismissable").remove();
                     jquery("#destinationLoginForm").before(html);
                 }
             })
             .fail(function (response) {
                 console.log(response.statusText);
                 var html = jquery("#loginErrorTemplate").html();
+                jquery(".alert-danger.alert-dismissable").remove();
                 jquery("#destinationLoginForm").before(html);
             })
             .always(function () {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,7 +1,7 @@
 require([
     "jquery",
-    "portal",
-    "info",
+    "portal/portal",
+    "portal/info",
     "mustache",
     "nprogress",
     "esri/arcgis/Portal",
@@ -235,7 +235,7 @@ require([
     };
 
     var inspectContent = function () {
-        require(["nprogress", "portal", "highlight"],
+        require(["nprogress", "portal/portal", "highlight"],
             function (NProgress, portal, hljs) {
 
                 var validateJson = function (jsonString) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -240,7 +240,7 @@ require([
         NProgress.start();
         portal.search(portalUrl, query, 100, "numViews", "desc", token)
             .done(function (results) {
-                listSearchItems(results);
+                listSearchItems(portalUrl, results);
                 NProgress.done();
             });
 
@@ -397,12 +397,22 @@ require([
 
                 // Add a listener for clicking on content buttons.
                 jquery(".content").click(function () {
-                    var server = app.user.server;
-                    var token = app.user.token;
+                    var server = jquery(this).attr("data-portal");
                     var id = jquery(this).attr("data-id");
                     var title = jquery(this).text();
                     var itemDescription;
                     var itemData;
+                    var token;
+                    
+                    /**
+                     * Append the token only for content in the user's portal.
+                     * This prevents trying to pass a portal token when 
+                     * inspecting content from an ArcGIS Online search.
+                     */
+                    if (server === app.user.server) {
+                        token = app.user.token;
+                    }
+                    
                     NProgress.start();
                     jquery(".content").addClass("btn-info");
                     jquery(".content").removeClass("active");
@@ -980,7 +990,7 @@ require([
         }
     };
 
-    var listSearchItems = function (results) {
+    var listSearchItems = function (portalUrl, results) {
         "use strict";
         clearResults();
         cleanUp();
@@ -998,7 +1008,8 @@ require([
                 "id": this.id,
                 "title": this.title,
                 "type": this.type,
-                "icon": info.items(this.type).icon
+                "icon": info.items(this.type).icon,
+                "portal": portalUrl
             };
             var html = mustache.to_html(jquery("#contentTemplate").html(), templateData);
             jquery("#collapse_search").append(html)
@@ -1059,7 +1070,8 @@ require([
                     "id": this.id,
                     "title": this.title,
                     "type": this.type,
-                    "icon": info.items(this.type).icon
+                    "icon": info.items(this.type).icon,
+                    "portal": url
                 };
                 var html = mustache.to_html(jquery("#contentTemplate").html(), templateData);
                 jquery("#collapse_").append(html);
@@ -1083,7 +1095,8 @@ require([
                             "id": this.id,
                             "title": this.title,
                             "type": this.type,
-                            "icon": info.items(this.type).icon
+                            "icon": info.items(this.type).icon,
+                            "portal": url
                         };
                         var html = mustache.to_html(jquery("#contentTemplate").html(), templateData);
                         jquery("#collapse_" + content.currentFolder.id).append(html);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -50,6 +50,7 @@ require([
         var inputUrl = jquery.trim(jquery(el).val());
 
         portalUtil.fixUrl(inputUrl).done(function (portalUrl) {
+            jquery(el).val(portalUrl);
             var urlError = jquery("#urlErrorTemplate").html();
             var checkbox = jquery(el).parent().parent()
                 .find("input[type='checkbox']");

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -135,7 +135,6 @@ require([
         jquery("#portalLoginBtn").button("loading");
         portal.generateToken(portalUrl, username, password)
             .done(function (response) {
-                jquery("#portalLoginBtn").button("reset");
                 if (response.token) {
                     var user = {
                         token: response.token,
@@ -149,13 +148,14 @@ require([
                 } else if (response.error.code === 400) {
                     var html = jquery("#loginErrorTemplate").html();
                     jquery("#portalLoginForm").before(html);
-                    jquery("#portalLoginBtn").button("reset");
                 }
             })
             .fail(function (response) {
                 console.log(response.statusText);
                 var html = jquery("#loginErrorTemplate").html();
                 jquery("#portalLoginForm").before(html);
+            })
+            .always(function () {
                 jquery("#portalLoginBtn").button("reset");
             });
     };
@@ -168,7 +168,6 @@ require([
         jquery("#dropArea").empty();
         portal.generateToken(portalUrl, username, password)
             .done(function (response) {
-                jquery("#destinationLoginBtn").button("reset");
                 if (response.token) {
                     storeCredentials("destination", portalUrl, username,
                         response.token).
@@ -182,13 +181,14 @@ require([
                 } else if (response.error.code === 400) {
                     var html = jquery("#loginErrorTemplate").html();
                     jquery("#destinationLoginForm").before(html);
-                    jquery("#destinationLoginBtn").button("reset");
                 }
             })
             .fail(function (response) {
                 console.log(response.statusText);
                 var html = jquery("#loginErrorTemplate").html();
                 jquery("#destinationLoginForm").before(html);
+            })
+            .always(function () {
                 jquery("#destinationLoginBtn").button("reset");
             });
     };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -403,16 +403,16 @@ require([
                     var itemDescription;
                     var itemData;
                     var token;
-                    
+
                     /**
                      * Append the token only for content in the user's portal.
-                     * This prevents trying to pass a portal token when 
+                     * This prevents trying to pass a portal token when
                      * inspecting content from an ArcGIS Online search.
                      */
                     if (server === app.user.server) {
                         token = app.user.token;
                     }
-                    
+
                     NProgress.start();
                     jquery(".content").addClass("btn-info");
                     jquery(".content").removeClass("active");

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1166,6 +1166,7 @@ require([
             // Doing it here ensures all required libraries have loaded.
             jquery(".jumbotron > p > [data-action='login']")
                 .removeAttr("disabled");
+            jquery("a.portal-signin").attr("href", "#portalLoginModal");
 
             // Check for previously authenticated sessions.
             esriId.registerOAuthInfos([appInfo]);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -71,6 +71,8 @@ require([
         };
 
         fixUrl(jquery.trim(jquery(el).val())).done(function (url) {
+            var urlError = jquery("#urlErrorTemplate").html();
+            var checkbox = jquery(el).parent().parent().find("input[type='checkbox']");
             jquery(el).parent().removeClass("has-error");
             jquery(el).next().removeClass("glyphicon-ok");
             portal.version(url)
@@ -91,11 +93,10 @@ require([
                             console.log("API v" + data.currentVersion);
                             jquery(".alert-danger.alert-dismissable").remove();
                             jquery(el).next().addClass("glyphicon-ok");
-                            jquery("#sourceWebTierAuth").trigger("click");
+                            jquery(checkbox).trigger("click");
                         })
                         .fail(function (xhr, textStatus) {
                             // OK, it's really not working.
-                            var urlError = jquery("#urlErrorTemplate").html();
                             jquery.ajaxSetup({
                                 xhrFields: {
                                     withCredentials: false

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -171,14 +171,19 @@ require([
         portal.generateToken(portalUrl, username, password)
             .done(function (response) {
                 if (response.token) {
-                    storeCredentials("destination", portalUrl, username,
-                        response.token).
-                    then(function () {
-                        jquery("#copyModal").modal("hide");
-                        highlightCopyableContent();
-                        NProgress.start();
-                        showDestinationFolders();
-                        NProgress.done();
+                    var token = response.token;
+                    portal.self(portalUrl, token).done(function (data) {
+                        username = data.user.username;
+                        portalUrl = "https://" + data.portalHostname + "/";
+                        storeCredentials("destination", portalUrl, username,
+                                token)
+                            .then(function () {
+                                jquery("#copyModal").modal("hide");
+                                highlightCopyableContent();
+                                NProgress.start();
+                                showDestinationFolders();
+                                NProgress.done();
+                            });
                     });
                 } else if (response.error.code === 400) {
                     var html = jquery("#loginErrorTemplate").html();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -349,13 +349,14 @@ require([
         });
     }
 
-    function storeCredentials(direction, portal, username, token, callback) {
-        "use strict";
+    var storeCredentials = function (direction, portal, username, token) {
+        var deferred = jquery.Deferred();
         sessionStorage[direction + "Token"] = token;
         sessionStorage[direction + "Url"] = portal;
         sessionStorage[direction + "Username"] = username;
-        callback();
-    }
+        deferred.resolve();
+        return deferred.promise();
+    };
 
     function loginPortal() {
         var portalUrl = jquery("#portalUrl").val();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,7 @@
 require([
     "jquery",
     "portal",
+    "info",
     "mustache",
     "nprogress",
     "esri/arcgis/Portal",
@@ -12,6 +13,7 @@ require([
 ], function (
     jquery,
     portal,
+    info,
     mustache,
     NProgress,
     arcgisPortal,
@@ -966,105 +968,6 @@ require([
         }
     };
 
-    var itemInfo = function (type) {
-        var types = [
-            {
-                type: "Color Set",
-                icon: "datafilesGray"
-            },
-            {
-                type: "Document Link",
-                icon: "datafilesGray"
-            },
-            {
-                type: "Image Service",
-                icon: "imagery"
-            },
-            {
-                type: "Feature Collection",
-                icon: "features"
-            },
-            {
-                type: "Feature Collection Template",
-                icon: "file"
-            },
-            {
-                type: "Feature Layer",
-                icon: "features"
-            },
-            {
-                type: "Feature Service",
-                icon: "features"
-            },
-            {
-                type: "Geocoding Service",
-                icon: "layers"
-            },
-            {
-                type: "Geodata Service",
-                icon: "layers"
-            },
-            {
-                type: "Geometry Service",
-                icon: "layers"
-            },
-            {
-                type: "Geoprocessing Service",
-                icon: "layers"
-            },
-            {
-                type: "Globe Service",
-                icon: "layers"
-            },
-            {
-                type: "Network Analysis Service",
-                icon: "layers"
-            },
-            {
-                type: "Map Service",
-                icon: "layers"
-            },
-            {
-                type: "Mobile Application",
-                icon: "apps"
-            },
-            {
-                type: "Operation View",
-                icon: "apps"
-            },
-            {
-                type: "Service Definition",
-                icon: "datafiles"
-            },
-            {
-                type: "Symbol Set",
-                icon: "datafiles"
-            },
-            {
-                type: "Web Map",
-                icon: "maps"
-            },
-            {
-                type: "Web Mapping Application",
-                icon: "apps"
-            },
-            {
-                type: "WMS",
-                icon: "layers"
-            },
-        ];
-        var info = types.filter(function (item) {
-            return item.type === type;
-        })[0];
-        if (!info) {
-            // Handle types not found in the above list.
-            return {
-                icon: "datafilesGray"
-            };
-        }
-        return info;
-    };
-
     var listSearchItems = function (results) {
         "use strict";
         clearResults();
@@ -1083,7 +986,7 @@ require([
                 "id": this.id,
                 "title": this.title,
                 "type": this.type,
-                "icon": itemInfo(this.type).icon
+                "icon": info.items(this.type).icon
             };
             var html = mustache.to_html(jquery("#contentTemplate").html(), templateData);
             jquery("#collapse_search").append(html)
@@ -1144,7 +1047,7 @@ require([
                     "id": this.id,
                     "title": this.title,
                     "type": this.type,
-                    "icon": itemInfo(this.type).icon
+                    "icon": info.items(this.type).icon
                 };
                 var html = mustache.to_html(jquery("#contentTemplate").html(), templateData);
                 jquery("#collapse_").append(html);
@@ -1168,7 +1071,7 @@ require([
                             "id": this.id,
                             "title": this.title,
                             "type": this.type,
-                            "icon": itemInfo(this.type).icon
+                            "icon": info.items(this.type).icon
                         };
                         var html = mustache.to_html(jquery("#contentTemplate").html(), templateData);
                         jquery("#collapse_" + content.currentFolder.id).append(html);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -31,7 +31,7 @@ require([
     jquery(document).ready(function () {
 
         // Resize the content areas to fill the window.
-        var resizeContentAreas = function resizeContentAreas() {
+        var resizeContentAreas = function () {
             "use strict";
             jquery(".itemArea").height(jquery(window).height() - 50);
         };
@@ -39,7 +39,7 @@ require([
 
         // Disable the enter key to prevent accidentally firing forms.
         // Disable it for everything except the code edit windows.
-        var disableEnterKey = function disableEnterKey() {
+        var disableEnterKey = function () {
             "use strict";
             jquery("html").bind("keypress", function (e) {
                 if (e.keyCode === 13 &&
@@ -112,6 +112,11 @@ require([
                 }
             }, 500);
         });
+    });
+
+    // Load the html templates.
+    jquery.get("templates.html", function (templates) {
+        jquery("body").append(templates);
     });
 
     // *** ArcGIS OAuth ***
@@ -222,10 +227,6 @@ require([
         }
     });
 
-    // Load the html templates.
-    jquery.get("templates.html", function (templates) {
-        jquery("body").append(templates);
-    });
 
     jquery(document).on("click", "li [data-action]", function (e) {
         // Highlight the selected action except for "View My Stats."
@@ -269,7 +270,7 @@ require([
      * Check the url for errors (e.g. no trailing slash)
      * and update it before sending.
      */
-    function validateUrl(el) {
+    var validateUrl = function (el) {
         "use strict";
         var portalUrl = jquery.trim(jquery(el).val());
         var html = jquery("#urlErrorTemplate").html();
@@ -306,9 +307,9 @@ require([
                 jquery(el).parent().after(html);
             });
         });
-    }
+    };
 
-    function startSession(user) {
+    var startSession = function (user) {
         "use strict";
         var searchHtml;
         var portalUrl = user.server + "/";
@@ -347,7 +348,7 @@ require([
             listUserItems();
             NProgress.done();
         });
-    }
+    };
 
     var storeCredentials = function (direction, portal, username, token) {
         var deferred = jquery.Deferred();
@@ -358,7 +359,7 @@ require([
         return deferred.promise();
     };
 
-    function loginPortal() {
+    var loginPortal = function () {
         var portalUrl = jquery("#portalUrl").val();
         var username = jquery("#portalUsername").val();
         var password = jquery("#portalPassword").val();
@@ -390,9 +391,9 @@ require([
                 jquery("#portalLoginForm").before(html);
                 jquery("#portalLoginBtn").button("reset");
             });
-    }
+    };
 
-    function loginDestination() {
+    var loginDestination = function () {
         var portalUrl = jquery("#destinationUrl").val();
         var username = jquery("#destinationUsername").val();
         var password = jquery("#destinationPassword").val();
@@ -423,9 +424,9 @@ require([
                 jquery("#destinationLoginForm").before(html);
                 jquery("#destinationLoginBtn").button("reset");
             });
-    }
+    };
 
-    function logout() {
+    var logout = function () {
         sessionStorage.clear();
         app.user = {};
         app.stats.activities = {};
@@ -439,9 +440,9 @@ require([
         });
         esriId.destroyCredentials();
         window.location.reload();
-    }
+    };
 
-    function search() {
+    var search = function () {
 
         var query = jquery("#searchText").val();
         var portalUrl = jquery("#searchMenu li.active").attr("data-url");
@@ -462,9 +463,9 @@ require([
                 NProgress.done();
             });
 
-    }
+    };
 
-    function inspectContent() {
+    var inspectContent = function () {
         require(["nprogress", "portal", "highlight"],
             function (NProgress, portal, hljs) {
 
@@ -679,9 +680,9 @@ require([
                         });
                 });
             });
-    }
+    };
 
-    function updateWebmapServices() {
+    var updateWebmapServices = function () {
         var webmapData;
         var owner;
         var folder;
@@ -781,9 +782,9 @@ require([
                 });
         });
 
-    }
+    };
 
-    function updateContentUrls() {
+    var updateContentUrls = function () {
         var owner;
         var folder;
         var supportedContent = jquery(".content[data-type='Feature Service'], .content[data-type='Map Service'], .content[data-type='Image Service'], .content[data-type='KML'], .content[data-type='WMS'], .content[data-type='Geodata Service'], .content[data-type='Globe Service'], .content[data-type='Geometry Service'], .content[data-type='Geocoding Service'], .content[data-type='Network Analysis Service'], .content[data-type='Geoprocessing Service'], .content[data-type='Web Mapping Application'], .content[data-type='Mobile Application']");
@@ -840,9 +841,9 @@ require([
             });
         });
 
-    }
+    };
 
-    function viewStats() {
+    var viewStats = function () {
         portal.user.profile(app.user.server, app.user.userId, app.user.token)
             .done(function (user) {
 
@@ -904,9 +905,9 @@ require([
                 });
 
             });
-    }
+    };
 
-    function makeDraggable(el) {
+    var makeDraggable = function (el) {
         el.draggable({
             cancel: false,
             helper: "clone",
@@ -915,9 +916,9 @@ require([
             opacity: 0.7
         });
         el.removeAttr("disabled");
-    }
+    };
 
-    function makeDroppable(id) {
+    var makeDroppable = function (id) {
         // Make the drop area accept content items.
         jquery("#dropFolder_" + id).droppable({
             accept: ".content",
@@ -927,27 +928,27 @@ require([
                 moveItem(ui.draggable, jquery(this).parent().parent());
             }
         });
-    }
+    };
 
-    function cleanUp() {
+    var cleanUp = function () {
         jquery("#dropArea").empty(); //Clear any old items.
         jquery(".content").unbind("click"); // Remove old event handlers.
         jquery(".content").removeClass("active btn-primary btn-info ui-draggable");
         jquery(".content").attr("disabled", "disabled");
-    }
+    };
 
-    function clearResults() {
+    var clearResults = function () {
         // Clean up any existing content in the left hand column.
         jquery("#itemsArea").empty();
-    }
+    };
 
-    function highlightCopyableContent() {
+    var highlightCopyableContent = function () {
 
-        function setMaxWidth(el) {
+        var setMaxWidth = function (el) {
             // Set the max-width of folder items so they don't fill the body when dragging.
             var maxWidth = jquery("#itemsArea .in").width() ? jquery("#itemsArea .in").width() : 400;
             jquery(el).css("max-width", maxWidth); // Set the max-width so it doesn't fill the body when dragging.
-        }
+        };
 
         jquery("#itemsArea .content").each(function (i) {
             var type = jquery(this).attr("data-type");
@@ -957,9 +958,9 @@ require([
                 makeDraggable(jquery(this)); //Make the content draggable.
             }
         });
-    }
+    };
 
-    function highlightSupportedContent() {
+    var highlightSupportedContent = function () {
         // Highlight content supported by the currently selected action.
         switch (jquery("#actionDropdown li.active").attr("data-action")) {
         case "copyContent":
@@ -978,7 +979,7 @@ require([
             inspectContent();
             break;
         }
-    }
+    };
 
     /**
      * isSupported() returns true if the content type is supported
@@ -986,7 +987,7 @@ require([
      * @return (Boolean)
      * List of types available here: http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r3000000ms000000
      */
-    function isSupported(type) {
+    var isSupported = function (type) {
         // Check if the content type is supported.
         //
         var supportedTypes = [
@@ -1013,9 +1014,9 @@ require([
         if (jquery.inArray(type, supportedTypes) > -1) {
             return true;
         }
-    }
+    };
 
-    function isTypeText(type) {
+    var isTypeText = function (type) {
         var textTypes = [
             "Web Map",
             "Feature Collection",
@@ -1028,9 +1029,9 @@ require([
         if (jquery.inArray(type, textTypes) > -1) {
             return true;
         }
-    }
+    };
 
-    function isTypeUrl(type) {
+    var isTypeUrl = function (type) {
         var urlTypes = [
             "Feature Service",
             "Map Service",
@@ -1049,9 +1050,9 @@ require([
         if (jquery.inArray(type, urlTypes) > -1) {
             return true;
         }
-    }
+    };
 
-    function statsCalendar(activities) {
+    var statsCalendar = function (activities) {
         require(["d3", "cal-heatmap"], function (d3, CalHeatMap) {
             // Create a date object for three months ago.
             var today = new Date();
@@ -1085,9 +1086,9 @@ require([
                 domainDynamicDimension: false
             });
         });
-    }
+    };
 
-    function itemInfo(type) {
+    var itemInfo = function (type) {
         var types = [
             {
                 type: "Color Set",
@@ -1184,9 +1185,9 @@ require([
             };
         }
         return info;
-    }
+    };
 
-    function listSearchItems(results) {
+    var listSearchItems = function (results) {
         "use strict";
         clearResults();
         cleanUp();
@@ -1212,10 +1213,9 @@ require([
         });
 
         highlightSupportedContent();
+    };
 
-    }
-
-    function listUserItems() {
+    var listUserItems = function () {
         "use strict";
         cleanUp();
         clearResults();
@@ -1305,9 +1305,9 @@ require([
                 highlightSupportedContent();
             }, 1000);
         });
-    }
+    };
 
-    function showDestinationFolders() {
+    var showDestinationFolders = function () {
         "use strict";
         var url = sessionStorage.destinationUrl;
         var username = sessionStorage.destinationUsername;
@@ -1340,13 +1340,13 @@ require([
                 });
             });
         });
-    }
+    };
 
     /**
      * Move the content DOM element from the source
      * to the destination container on the page.
      */
-    function moveItem(item, destination) {
+    var moveItem = function (item, destination) {
         "use strict";
         var itemId = jquery(item).attr("data-id");
 
@@ -1369,14 +1369,14 @@ require([
         var destinationFolder = clone.parent().attr("data-folder");
 
         copyItem(itemId, destinationFolder);
-    }
+    };
 
     /**
      * copyItem() Copies a given item ID.
      * @id {String} ID of the source item
      * @folder {String} id of the destination folder
      */
-    function copyItem(id, folder) {
+    var copyItem = function (id, folder) {
         "use strict";
         var sourcePortal = app.user.server;
         var sourceToken = app.user.token;
@@ -1427,6 +1427,6 @@ require([
             jquery("#" + id).before(html);
             jquery("#" + id + "_alert").fadeOut(6000);
         }
-    }
+    };
 
 });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -220,6 +220,13 @@ require([
 
         var query = jquery("#searchText").val();
         var portalUrl = jquery("#searchMenu li.active").attr("data-url");
+        var token;
+        
+        // Append the token only for searches in the user's portal.
+        if (portalUrl === app.user.server) {
+            token = app.user.token;
+        }
+        
         // Add the org id for "My Portal" searches.
         if (jquery("#searchMenu li.active").attr("data-id")) {
             query += " accountid:" +
@@ -229,9 +236,9 @@ require([
         if (jquery("#searchMenu li.active").text() === "Search My Content") {
             query += " owner:" + app.user.userId;
         }
-
+        
         NProgress.start();
-        portal.search(portalUrl, query, 100, "numViews", "desc", app.user.token)
+        portal.search(portalUrl, query, 100, "numViews", "desc", token)
             .done(function (results) {
                 listSearchItems(results);
                 NProgress.done();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,11 +35,13 @@ require([
     var app = {
         stats: {
             activities: {}
-        },
+        }
     };
     var sourcePortal = new portalSelf.Portal();
     var destinationPortal = new portalSelf.Portal();
-    var arcgisOnline = new portalSelf.Portal("https://www.arcgis.com/");
+    var arcgisOnline = new portalSelf.Portal({
+        portalUrl: "https://www.arcgis.com/"
+    });
 
     /**
      * Check the url for errors (e.g. no trailing slash)
@@ -211,8 +213,6 @@ require([
 
         var query = jquery("#searchText").val();
         var portalUrl = jquery("#searchMenu li.active").attr("data-url");
-        var token;
-
         // Add the org id for "My Portal" searches.
         if (jquery("#searchMenu li.active").attr("data-id")) {
             query += " accountid:" +

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -23,7 +23,8 @@ require([
     // *** ArcGIS OAuth ***
     var appInfo = new arcgisOAuthInfo({
         appId: "4E1s0Mv5r0c2l6W8",
-        popup: true
+        popup: true,
+        portalUrl: "https://www.arcgis.com/"
     });
 
     // Some app level variables.
@@ -77,23 +78,23 @@ require([
         });
     };
 
-    var startSession = function (user) {
+    var startSession = function (portalUrl, user) {
         "use strict";
         var searchHtml;
-        var portalUrl = user.server + "/";
         var token = user.token;
         app.user = user;
-        app.user.server = app.user.server + "/";
         portal.self(portalUrl, token).done(function (data) {
             var template = jquery("#sessionTemplate").html();
             var html = mustache.to_html(template, data);
+            app.user.userId = data.user.username;
+            app.user.server = "https://" + data.portalHostname + "/";
             jquery(".nav.navbar-nav").after(html);
             jquery("#logout").show();
             jquery("#actionDropdown").css({
                 "visibility": "visible"
             });
             searchHtml = mustache.to_html(jquery("#searchTemplate").html(), {
-                portal: portalUrl,
+                portal: app.user.server,
                 name: data.name,
                 id: data.id
             });
@@ -137,8 +138,6 @@ require([
                 jquery("#portalLoginBtn").button("reset");
                 if (response.token) {
                     var user = {
-                        userId: username,
-                        server: portalUrl,
                         token: response.token,
                         expires: response.expires,
                         ssl: response.ssl
@@ -146,7 +145,7 @@ require([
                     jquery("#portalLoginModal").modal("hide");
                     jquery("#splashContainer").css("display", "none");
                     jquery("#itemsContainer").css("display", "block");
-                    startSession(user);
+                    startSession(portalUrl, user);
                 } else if (response.error.code === 400) {
                     var html = jquery("#loginErrorTemplate").html();
                     jquery("#portalLoginForm").before(html);
@@ -1247,8 +1246,7 @@ require([
                         jquery("#splashContainer").css("display", "none");
                         jquery("#itemsContainer").css("display", "block");
                         app.user = user;
-                        app.user.server = app.user.server + "/";
-                        startSession(user);
+                        startSession(appInfo.portalUrl, user);
                     })
                 .otherwise(
                     function () {
@@ -1345,7 +1343,7 @@ require([
                 .then(function (user) {
                     jquery("#splashContainer").css("display", "none");
                     jquery("#itemsContainer").css("display", "block");
-                    startSession(user);
+                    startSession(appInfo.portalUrl, user);
                 });
         });
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -44,7 +44,6 @@ require([
     var validateUrl = function (el) {
         "use strict";
         var portalUrl = jquery.trim(jquery(el).val());
-        var html = jquery("#urlErrorTemplate").html();
         var fixUrl = function (url) {
             var deferred = jquery.Deferred();
             if (portalUrl === "") {
@@ -72,11 +71,15 @@ require([
         };
 
         fixUrl(jquery.trim(jquery(el).val())).done(function (url) {
-            portal.version(url).done(function (data) {
-                console.log("API v" + data.currentVersion);
-            }).fail(function (response) {
-                jquery(el).parent().after(html);
-            });
+            portal.version(url)
+                .done(function (data) {
+                    console.log("API v" + data.currentVersion);
+                })
+                .fail(function (xhr, textStatus) {
+                    var html = jquery("#urlErrorTemplate").html();
+                    jquery(".alert-danger.alert-dismissable").remove();
+                    jquery(el).parent().parent().after(html);
+                });
         });
     };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1185,11 +1185,13 @@ require([
         };
         disableEnterKey();
 
-
         // Preformat the copy login screen.
         jquery("#destinationAgolBtn").button("toggle");
         jquery("#destinationAgolBtn").addClass("btn-primary");
         jquery("#destinationUrl").css({
+            "visibility": "hidden"
+        });
+        jquery("#destinationWebTierAuth").css({
             "visibility": "hidden"
         });
 
@@ -1203,6 +1205,9 @@ require([
             jquery("#destinationUrl").css({
                 "visibility": "hidden"
             });
+            jquery("#destinationWebTierAuth").css({
+                "visibility": "hidden"
+            });
             jquery("#destinationAgolBtn").addClass("btn-primary active");
             jquery("#destinationPortalBtn").removeClass("btn-primary active");
         });
@@ -1213,6 +1218,9 @@ require([
             });
             jquery("#destinationUrl").val("");
             jquery("#destinationUrl").css({
+                "visibility": "visible"
+            });
+            jquery("#destinationWebTierAuth").css({
                 "visibility": "visible"
             });
             jquery("#destinationPortalBtn").addClass("btn-primary active");
@@ -1242,6 +1250,36 @@ require([
                     validateUrl("#destinationUrl");
                 }
             }, 500);
+        });
+        
+        // Disable username and password if web tier auth is selected.
+        jquery("#sourceWebTierAuth").click(function(e){
+            var checkboxState = jquery(e.currentTarget).prop("checked");
+            if (checkboxState === true) {
+                jquery("#portalUsername").attr("disabled", true);
+                jquery("#portalPassword").attr("disabled", true);
+                jquery("#portalLoginBtn").text("Proceed");
+            }
+            else {
+                jquery("#portalUsername").removeAttr("disabled");
+                jquery("#portalPassword").removeAttr("disabled");
+                jquery("#portalLoginBtn").text("Log in");
+            }
+        });
+        
+        // Disable username and password if web tier auth is selected.
+        jquery("#destWebTierAuthChk").click(function(e){
+            var checkboxState = jquery(e.currentTarget).prop("checked");
+            if (checkboxState === true) {
+                jquery("#destinationUsername").attr("disabled", true);
+                jquery("#destinationPassword").attr("disabled", true);
+                jquery("#destinationLoginBtn").text("Proceed");
+            }
+            else {
+                jquery("#destinationUsername").removeAttr("disabled");
+                jquery("#destinationPassword").removeAttr("disabled");
+                jquery("#destinationLoginBtn").text("Log in");
+            }
         });
 
         // Login.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -221,12 +221,12 @@ require([
         var query = jquery("#searchText").val();
         var portalUrl = jquery("#searchMenu li.active").attr("data-url");
         var token;
-        
+
         // Append the token only for searches in the user's portal.
         if (portalUrl === app.user.server) {
             token = app.user.token;
         }
-        
+
         // Add the org id for "My Portal" searches.
         if (jquery("#searchMenu li.active").attr("data-id")) {
             query += " accountid:" +
@@ -236,7 +236,7 @@ require([
         if (jquery("#searchMenu li.active").text() === "Search My Content") {
             query += " owner:" + app.user.userId;
         }
-        
+
         NProgress.start();
         portal.search(portalUrl, query, 100, "numViews", "desc", token)
             .done(function (results) {
@@ -1258,34 +1258,52 @@ require([
                 }
             }, 500);
         });
-        
+
         // Disable username and password if web tier auth is selected.
-        jquery("#sourceWebTierAuth").click(function(e){
+        jquery("#sourceWebTierAuth").click(function (e) {
             var checkboxState = jquery(e.currentTarget).prop("checked");
             if (checkboxState === true) {
                 jquery("#portalUsername").attr("disabled", true);
                 jquery("#portalPassword").attr("disabled", true);
                 jquery("#portalLoginBtn").text("Proceed");
-            }
-            else {
+                jquery.ajaxSetup({
+                    xhrFields: {
+                        withCredentials: true
+                    }
+                });
+            } else {
                 jquery("#portalUsername").removeAttr("disabled");
                 jquery("#portalPassword").removeAttr("disabled");
                 jquery("#portalLoginBtn").text("Log in");
+                jquery.ajaxSetup({
+                    xhrFields: {
+                        withCredentials: false
+                    }
+                });
             }
         });
-        
+
         // Disable username and password if web tier auth is selected.
-        jquery("#destWebTierAuthChk").click(function(e){
+        jquery("#destWebTierAuthChk").click(function (e) {
             var checkboxState = jquery(e.currentTarget).prop("checked");
             if (checkboxState === true) {
                 jquery("#destinationUsername").attr("disabled", true);
                 jquery("#destinationPassword").attr("disabled", true);
                 jquery("#destinationLoginBtn").text("Proceed");
-            }
-            else {
+                jquery.ajaxSetup({
+                    xhrFields: {
+                        withCredentials: true
+                    }
+                });
+            } else {
                 jquery("#destinationUsername").removeAttr("disabled");
                 jquery("#destinationPassword").removeAttr("disabled");
                 jquery("#destinationLoginBtn").text("Log in");
+                jquery.ajaxSetup({
+                    xhrFields: {
+                        withCredentials: false
+                    }
+                });
             }
         });
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -443,12 +443,13 @@ require([
                                     jquery(".btn-default[data-action='startEdits']").click(function (e) {
                                         if (!localStorage.hasOwnProperty("editsAllowed")) {
                                             // Show the caution modal.
+                                            var editJsonBtn = jquery("#editJsonBtn");
                                             jquery("#editJsonModal").modal("show");
-                                            jquery(".acknowledgeRisk").click(function () {
+                                            jquery(".acknowledgeRisk").click(function (e) {
                                                 if (jquery(e.currentTarget).prop("checked")) {
-                                                    jquery("#editJsonBtn").removeClass("disabled");
+                                                    editJsonBtn.removeClass("disabled");
                                                 } else {
-                                                    jquery("#editJsonBtn").addClass("disabled");
+                                                    editJsonBtn.addClass("disabled");
                                                 }
                                             });
                                         } else {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -97,9 +97,6 @@ require([
                 name: data.name,
                 id: data.id
             });
-            console.log("template", template);
-            console.log("searchHtml", searchHtml);
-            console.log("html", html);
             jquery("#actionDropdown").before(searchHtml);
 
             // Add a listener for clicking the search icon.
@@ -1206,12 +1203,10 @@ require([
 
     // Do stuff when the DOM is ready.
     jquery(document).ready(function () {
-        console.log("loaded");
 
         // Load the html templates.
         jquery.get("templates.html", function (templates) {
             jquery("body").append(templates);
-            console.log("appended");
 
             // Enable the login button.
             // Doing it here ensures all required libraries have loaded.

--- a/src/js/portal/info.js
+++ b/src/js/portal/info.js
@@ -1,0 +1,102 @@
+define([], function () {
+    var types = [
+        {
+            type: "Color Set",
+            icon: "datafilesGray"
+        },
+        {
+            type: "Document Link",
+            icon: "datafilesGray"
+        },
+        {
+            type: "Image Service",
+            icon: "imagery"
+        },
+        {
+            type: "Feature Collection",
+            icon: "features"
+        },
+        {
+            type: "Feature Collection Template",
+            icon: "file"
+        },
+        {
+            type: "Feature Layer",
+            icon: "features"
+        },
+        {
+            type: "Feature Service",
+            icon: "features"
+        },
+        {
+            type: "Geocoding Service",
+            icon: "layers"
+        },
+        {
+            type: "Geodata Service",
+            icon: "layers"
+        },
+        {
+            type: "Geometry Service",
+            icon: "layers"
+        },
+        {
+            type: "Geoprocessing Service",
+            icon: "layers"
+        },
+        {
+            type: "Globe Service",
+            icon: "layers"
+        },
+        {
+            type: "Network Analysis Service",
+            icon: "layers"
+        },
+        {
+            type: "Map Service",
+            icon: "layers"
+        },
+        {
+            type: "Mobile Application",
+            icon: "apps"
+        },
+        {
+            type: "Operation View",
+            icon: "apps"
+        },
+        {
+            type: "Service Definition",
+            icon: "datafiles"
+        },
+        {
+            type: "Symbol Set",
+            icon: "datafiles"
+        },
+        {
+            type: "Web Map",
+            icon: "maps"
+        },
+        {
+            type: "Web Mapping Application",
+            icon: "apps"
+        },
+        {
+            type: "WMS",
+            icon: "layers"
+        },
+    ];
+    return {
+        items: function (type) {
+            var info = types.filter(function (item) {
+                return item.type === type;
+            })[0];
+            if (!info) {
+                // Handle types not found in the above list.
+                return {
+                    icon: "datafilesGray"
+                };
+            }
+            return info;
+        }
+    };
+});

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -1,110 +1,149 @@
 define(["jquery", "portal/util"], function (jquery, util) {
     return {
-        version: function (portal) {
-            // Returns the version of the portal.
-            return jquery.ajax({
-                type: "GET",
-                url: portal + "sharing/rest?f=json",
-                dataType: "json"
-            });
-        },
-        self: function (portal, token) {
-            // Return the view of the portal as seen by the current user, anonymous or logged in.
-            return jquery.ajax({
-                type: "GET",
-                url: portal + "sharing/rest/portals/self?" + jquery.param({
-                    token: token,
-                    f: "json"
-                }),
-                dataType: "json"
-            });
-        },
-        generateToken: function (portal, username, password) {
-            // Generates an access token in exchange for user credentials that can be used by clients when working with the ArcGIS Portal API.
-            return jquery.ajax({
-                type: "POST",
-                url: portal + "sharing/rest/generateToken?",
-                data: {
-                    username: username,
-                    password: password,
-                    referer: jquery(location).attr("href"), // URL of the sending app.
-                    expiration: 60, // Lifetime of the token in minutes.
-                    f: "json"
-                },
-                dataType: "json"
-            });
-        },
-        search: function (portal, query, numResults, sortField, sortOrder, token) {
-            // Searches for content items in the portal.
-            // The results of a search only contain items that the user (token) has permission to access.
-            // Excluding a token will yield only public items.
-            return jquery.ajax({
-                type: "GET",
-                url: portal + "sharing/rest/search?",
-                data: {
-                    q: query,
-                    num: numResults,
-                    sortField: sortField,
-                    sortOrder: sortOrder,
-                    token: token,
-                    f: "json"
-                },
-                dataType: "json"
-            });
-        },
-        user: {
-            profile: function (portal, username, token) {
+        Portal: function (portalUrl, token) {
+            this.portalUrl = portalUrl;
+            this.username = null;
+            this.token = token;
+            this.withCredentials = false;
+            /**
+             * Return the version of the portal.
+             */
+            this.version = function () {
+                return jquery.ajax({
+                    type: "GET",
+                    url: this.portalUrl + "sharing/rest?f=json",
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * Return the view of the portal as seen by the current user,
+             * anonymous or logged in.
+             */
+            this.self = function () {
+                return jquery.ajax({
+                    type: "GET",
+                    url: this.portalUrl + "sharing/rest/portals/self?" + jquery.param({
+                        token: this.token,
+                        f: "json"
+                    }),
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * Generates an access token in exchange for user credentials that
+             * can be used by clients when working with the ArcGIS Portal API.
+             */
+            this.generateToken = function (username, password) {
+                return jquery.ajax({
+                    type: "POST",
+                    url: this.portalUrl + "sharing/rest/generateToken?",
+                    data: {
+                        username: username,
+                        password: password,
+                        referer: jquery(location).attr("href"), // URL of the sending app.
+                        expiration: 60, // Lifetime of the token in minutes.
+                        f: "json"
+                    },
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * Searches for content items in the portal.
+             * The results of a search only contain items that the user
+             * (token) has permission to access.
+             * Excluding a token will yield only public items.
+             */
+            this.search = function (query, numResults, sortField, sortOrder) {
+                return jquery.ajax({
+                    type: "GET",
+                    url: this.portalUrl + "sharing/rest/search?",
+                    data: {
+                        q: query,
+                        num: numResults,
+                        sortField: sortField,
+                        sortOrder: sortOrder,
+                        token: this.token,
+                        f: "json"
+                    },
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            this.userProfile = function (username) {
                 // 
                 return jquery.ajax({
                     type: "GET",
-                    url: portal + "sharing/rest/community/users/" + username + "?",
+                    url: this.portalUrl + "sharing/rest/community/users/" + username + "?",
                     data: {
-                        token: token,
+                        token: this.token,
                         f: "json"
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-            content: function (portal, username, folder, token) {
+            };
+            this.userContent = function (username, folder) {
                 // 
                 return jquery.ajax({
                     type: "GET",
-                    url: portal + "sharing/rest/content/users/" + username + "/" + folder + "?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "?",
                     data: {
-                        token: token,
+                        token: this.token,
                         f: "json"
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-        },
-        content: {
-            itemDescription: function (portal, id, token) {
+            };
+            this.itemDescription = function (id) {
                 // 
                 return jquery.ajax({
                     type: "GET",
-                    url: portal + "sharing/rest/content/items/" + id + "?",
+                    url: this.portalUrl + "sharing/rest/content/items/" + id + "?",
                     data: {
-                        token: token,
+                        token: this.token,
                         f: "json"
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-            itemData: function (portal, id, token) {
+            };
+            this.itemData = function (id) {
                 // 
                 return jquery.ajax({
                     type: "GET",
-                    url: portal + "sharing/rest/content/items/" + id + "/data?",
+                    url: this.portalUrl + "sharing/rest/content/items/" + id + "/data?",
                     data: {
-                        token: token,
+                        token: this.token,
                         f: "json"
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-            addItem: function (portal, username, folder, description, data, thumbnailUrl, token) {
-                // Create a new item on the specified portal.
+            };
+            /**
+             * Create a new item on the specified portal.
+             */
+            this.addItem = function (username, folder, description, data, thumbnailUrl) {
 
                 // Clean up description items for posting.
                 // This is necessary because some of the item descriptions (e.g. tags and extent)
@@ -124,34 +163,47 @@ define(["jquery", "portal/util"], function (jquery, util) {
                     overwrite: false, // Prevent users from accidentally overwriting items with the same name.
                     thumbnailurl: thumbnailUrl,
                     f: "json",
-                    token: token
+                    token: this.token
                 };
                 return jquery.ajax({
                     type: "POST",
-                    url: portal + "sharing/rest/content/users/" + username + "/" + folder + "/addItem?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/addItem?",
                     data: jquery.extend(description, params), // Merge the description and params JSON objects.
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-            updateWebmapData: function (portal, username, folder, id, data, token) {
-                // Update the content in a web map.
+            };
+            /**
+             * Update the content in a web map.
+             */
+            this.updateWebmapData = function (username, folder, id, data) {
                 return jquery.ajax({
                     type: "POST",
-                    url: portal + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
                     data: {
                         text: JSON.stringify(data), // Stringify the Javascript object so it can be properly sent.
-                        token: token,
+                        token: this.token,
                         f: "json"
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-            updateDescription: function (portal, username, id, folder, description, token) {
-                // Update the description for an item.
-                // Clean up description items for posting.
-                // This is necessary because some of the item descriptions (e.g. tags and extent)
-                // are returned as arrays, but the post operation expects comma separated strings.
+            };
+            /**
+             * Update the description for an item.
+             */
+            this.updateDescription = function (username, id, folder, description) {
                 var postData = JSON.parse(description);
+                /**
+                 * Clean up description items for posting.
+                 * This is necessary because some of the item descriptions
+                 * (e.g. tags and extent) are returned as arrays, but the post
+                 * operation expects comma separated strings.
+                 */
                 jquery.each(postData, function (item, value) {
                     if (value === null) {
                         postData[item] = "";
@@ -159,41 +211,52 @@ define(["jquery", "portal/util"], function (jquery, util) {
                         postData[item] = value.join(",");
                     }
                 });
-                postData.token = token;
+                postData.token = this.token;
                 postData.f = "json";
                 return jquery.ajax({
                     type: "POST",
-                    url: portal + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
                     data: postData,
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-            updateData: function (portal, username, id, folder, data, token) {
+            };
+            this.updateData = function (username, id, folder, data) {
                 // Update the content in a web map.
                 return jquery.ajax({
                     type: "POST",
-                    url: portal + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
                     data: {
                         text: data, // Stringify the Javascript object so it can be properly sent.
-                        token: token,
+                        token: this.token,
                         f: "json"
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            },
-            updateUrl: function (portal, username, folder, id, url, token) {
-                // Update the URL of a registered service or web application.
+            };
+            /**
+             * Update the URL of a registered service or web application.
+             */
+            this.updateUrl = function (username, folder, id, url) {
                 return $.ajax({
                     type: "POST",
-                    url: portal + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
                     data: {
                         url: url,
-                        token: token,
+                        token: this.token,
                         f: "json"
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
                 });
-            }
+            };
         }
     };
 });

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -1,4 +1,4 @@
-define(["jquery", "util"], function (jquery, util) {
+define(["jquery", "portal/util"], function (jquery, util) {
     return {
         version: function (portal) {
             // Returns the version of the portal.

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -1,9 +1,10 @@
 define(["jquery", "portal/util"], function (jquery, util) {
     return {
-        Portal: function (portalUrl, token) {
-            this.portalUrl = portalUrl;
-            this.username = null;
-            this.token = token;
+        Portal: function (config) {
+            config = typeof config !== "undefined" ? config : {};
+            this.portalUrl = config.portalUrl;
+            this.username = config.username;
+            this.token = config.token;
             this.withCredentials = false;
             /**
              * Return the version of the portal.

--- a/src/js/portal/util.js
+++ b/src/js/portal/util.js
@@ -1,7 +1,7 @@
 define(["jquery"], function (jquery) {
     return {
+        // Convert an array to a comma separated string.
         arrayToString: function (array) {
-            // Convert an array to a comma separated string.
             var arrayString;
             jquery.each(array, function (index, arrayValue) {
                 if (index === 0) {
@@ -11,6 +11,27 @@ define(["jquery"], function (jquery) {
                 }
             });
             return arrayString;
+        },
+        // Clean up common issues with user entered portal URLs.
+        fixUrl: function (portalUrl) {
+            var deferred = jquery.Deferred();
+            if (portalUrl === "") {
+                // Default to ArcGIS Online.
+                portalUrl = "https://www.arcgis.com/";
+            } else if (portalUrl.search("/home/") > 0) {
+                // Strip the /home endpoint.
+                portalUrl = portalUrl.
+                substr(0, portalUrl.search("/home/")) + "/";
+            } else if (portalUrl.search("/sharing/") > 0) {
+                // Strip the /sharing endpoint.
+                portalUrl = portalUrl.
+                substr(0, portalUrl.search("/sharing/")) + "/";
+            } else if (portalUrl.charAt(portalUrl.length - 1) !== "/") {
+                // Add the trailing slash.
+                portalUrl = portalUrl + "/";
+            }
+            deferred.resolve(portalUrl);
+            return deferred.promise();
         }
     };
 });

--- a/src/templates.html
+++ b/src/templates.html
@@ -25,7 +25,7 @@
 
 <script type="text/template" id="urlErrorTemplate">
 
-    <div class="alert alert-danger alert-dismissable" style="position: absolute; z-index: 99">
+    <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <p><strong>Uh oh!</strong> That doesn't appear to be a valid url.</p>
         <p>Try opening your Portal's homepage in another tab, then try again.</p>

--- a/src/templates.html
+++ b/src/templates.html
@@ -104,7 +104,7 @@
 
 <script type="text/template" id="contentTemplate">
 
-    <button id="{{ id }}" class="btn btn-default btn-block content" disabled="disabled" style="opacity: 1;" type="button" data-id="{{ id }}" data-type="{{ type }}">
+    <button id="{{ id }}" class="btn btn-default btn-block content" disabled="disabled" style="opacity: 1;" type="button" data-id="{{ id }}" data-type="{{ type }}" data-portal="{{ portal }}">
         <span class="icon {{ icon }}"></span>
         {{ title }}
     </button>

--- a/src/templates.html
+++ b/src/templates.html
@@ -27,8 +27,9 @@
 
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-        <p><strong>Uh oh!</strong> That doesn't appear to be a valid url.</p>
-        <p>Try opening your Portal's homepage in another tab, then try again.</p>
+        <p><strong>Uh oh! There's a problem with the url.</strong></p>
+        <p>Make sure you've entered the url to your portal's web adaptor.</p>
+        <p>example: https://mydomain.com/portal</p>
     </div>
 
 </script>

--- a/src/templates.html
+++ b/src/templates.html
@@ -36,7 +36,7 @@
 
 <script type="text/template" id="loginErrorTemplate">
 
-    <div class="alert alert-danger alert-dismissable" style="position: absolute; right: 10px; z-index: 99">
+    <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
         <strong>Whoops!</strong> Double check your username and password.
     </div>


### PR DESCRIPTION
  * IWA and PKI secured portals are now supported by setting `withCredentials` on requests to those portals (closes #54).
  * Big code cleanup in `main.js` hopefully makes for a more logical layout.
  * Refactored `portal.js` to allow usage of multiple, independent instances. Makes it much easier to set `withCredentials` for requests to one portal and not to another.
  * Closes #70.