### PR TITLE
Last resort jsonp request to address #99 and automatic https url upgrade for #98

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -80,20 +80,20 @@ require([
                             // Now try enterprise auth with jsonp so crossdomain will follow redirects.
                             portal.jsonp = true;
                             portal.version().done(function(data) {
-								// It worked so keep enterprise auth but turn jsonp back off.
-								portal.jsonp = false;
-								console.log("API v" + data.currentVersion);
-								jquery(".alert-danger.alert-dismissable").remove();
-								jquery(el).next().addClass("glyphicon-ok");
-							}).fail(function(xhr, textStatus) {
-								// OK, it's really not working.
-								console.log(xhr, textStatus);
-								portal.withCredentials = false;
-								portal.jsonp = false;
-								jquery(".alert-danger.alert-dismissable").remove();
-								jquery(el).parent().parent().after(urlError);
-								jquery(el).parent().addClass("has-error");
-							});
+                                // It worked so keep enterprise auth but turn jsonp back off.
+                                portal.jsonp = false;
+                                console.log("API v" + data.currentVersion);
+                                jquery(".alert-danger.alert-dismissable").remove();
+                                jquery(el).next().addClass("glyphicon-ok");
+                            }).fail(function(xhr, textStatus) {
+                                // OK, it's really not working.
+                                console.log(xhr, textStatus);
+                                portal.withCredentials = false;
+                                portal.jsonp = false;
+                                jquery(".alert-danger.alert-dismissable").remove();
+                                jquery(el).parent().parent().after(urlError);
+                                jquery(el).parent().addClass("has-error");
+                            });
                         });
                 });
         });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -77,12 +77,23 @@ require([
                             jquery(checkbox).trigger("click");
                         })
                         .fail(function(xhr, textStatus) {
-                            // OK, it's really not working.
-                            console.log(xhr, textStatus);
-                            portal.withCredentials = false;
-                            jquery(".alert-danger.alert-dismissable").remove();
-                            jquery(el).parent().parent().after(urlError);
-                            jquery(el).parent().addClass("has-error");
+                            // Now try enterprise auth with jsonp so crossdomain will follow redirects.
+                            portal.jsonp = true;
+                            portal.version().done(function(data) {
+								// It worked so keep enterprise auth but turn jsonp back off.
+								portal.jsonp = false;
+								console.log("API v" + data.currentVersion);
+								jquery(".alert-danger.alert-dismissable").remove();
+								jquery(el).next().addClass("glyphicon-ok");
+							}).fail(function(xhr, textStatus) {
+								// OK, it's really not working.
+								console.log(xhr, textStatus);
+								portal.withCredentials = false;
+								portal.jsonp = false;
+								jquery(".alert-danger.alert-dismissable").remove();
+								jquery(el).parent().parent().after(urlError);
+								jquery(el).parent().addClass("has-error");
+							});
                         });
                 });
         });

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -6,18 +6,31 @@ define(["jquery", "portal/util"], function(jquery, util) {
             this.username = config.username;
             this.token = config.token;
             this.withCredentials = false;
+            this.jsonp = false;
             /**
              * Return the version of the portal.
              */
             this.version = function() {
-                return jquery.ajax({
-                    type: "GET",
-                    url: this.portalUrl + "sharing/rest?f=json",
-                    dataType: "json",
-                    xhrFields: {
-                        withCredentials: this.withCredentials
-                    }
-                });
+                if (this.jsonp) {
+                    return jquery.ajax({
+                        type: 'GET',
+                        url: this.portalUrl + "sharing/rest?f=json",
+                        async: false,
+                        jsonpCallback: 'callback',
+                        crossdomain: true,
+                        contentType: "application/json",
+                        dataType: "jsonp"
+                    });
+                } else {
+                    return jquery.ajax({
+                        type: "GET",
+                        url: this.portalUrl + "sharing/rest?f=json",
+                        dataType: "json",
+                        xhrFields: {
+                            withCredentials: this.withCredentials
+                        }
+                    });
+                }
             };
             /**
              * Return the view of the portal as seen by the current user,

--- a/src/js/portal/util.js
+++ b/src/js/portal/util.js
@@ -33,6 +33,10 @@ define(["jquery"], function(jquery) {
                 portalUrl = portalUrl + "/";
             }
 
+            if (portalUrl.indexOf("http://") === 0 && window.location.href.indexOf("https://") === 0) {    
+                portalUrl = portalUrl.replace("http://", "https://");
+            }
+
             deferred.resolve(portalUrl);
             return deferred.promise();
         }

--- a/src/js/portal/util.js
+++ b/src/js/portal/util.js
@@ -33,7 +33,7 @@ define(["jquery"], function(jquery) {
                 portalUrl = portalUrl + "/";
             }
 
-            if (portalUrl.indexOf("http://") === 0 && window.location.href.indexOf("https://") === 0) {    
+            if (portalUrl.indexOf("http://") === 0 && window.location.href.indexOf("https://") === 0) {
                 portalUrl = portalUrl.replace("http://", "https://");
             }
 


### PR DESCRIPTION
Proposed fix for #99. Adding a last resort jsonp request to the validateUrl check for cases where the PKI server does an HTTP 302 redirect that does not contain CORS headers.