### PR TITLE
Added deep copying for feature services

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -3,6 +3,12 @@
     <h3 id="changelogModalLabel">Changelog</h3>
 </div>
 <div class="modal-body">
+    <p>November 2015</p>
+    <ul>
+        <li>Added support for updating the URLs of tables in a web map.</li>
+        <li>Enabled option to "Full Copy" a feature service. This creates a clone of the original feature service in the destination account including data and styling.</li>
+        <li>Fixed some bugs with the sign in process.</li>
+    </ul>
     <p>July 2015</p>
     <ul>
         <li>Added support for working with Scenes (Web Scenes, Scene Layers, etc).</li>

--- a/src/css/grid.svg
+++ b/src/css/grid.svg
@@ -1,0 +1,56 @@
+<svg width="105" height="105" viewBox="0 0 105 105" xmlns="http://www.w3.org/2000/svg" fill="#fff">
+    <circle cx="12.5" cy="12.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="0s" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="12.5" cy="52.5" r="12.5" fill-opacity=".5">
+        <animate attributeName="fill-opacity"
+         begin="100ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="52.5" cy="12.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="300ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="52.5" cy="52.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="600ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="92.5" cy="12.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="800ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="92.5" cy="52.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="400ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="12.5" cy="92.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="700ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="52.5" cy="92.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="500ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+    <circle cx="92.5" cy="92.5" r="12.5">
+        <animate attributeName="fill-opacity"
+         begin="200ms" dur="1s"
+         values="1;.2;1" calcMode="linear"
+         repeatCount="indefinite" />
+    </circle>
+</svg>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -104,6 +104,13 @@ body {
     font-size: .8em;
 }
 
+.harvester {
+    display: block;
+    float: right;
+    height: 20px;
+    width: 20px;
+}
+
 .apps {
     background:url(../assets/images/apps16.png);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -111,7 +111,6 @@
                                     Copy content between accounts (even on different organizations or Portals)
                                     <ul>
                                         <li><em>Files cannot be copied at this time.</em></li>
-                                        <li><em>Copying hosted feature services adds a reference to the original service in the destination portal. Deep copying is planned for a future release.</em></li>
                                     </ul>
                                 </li>
                                 <li>Inspect content</li>
@@ -304,7 +303,7 @@
                             <div class="alert alert-info">
                                 <p><strong>Simple copy</strong> creates a reference to the original service 
                                     in the destination account.</p>
-                                <p><strong>Full copy</strong> replicates the original service in the
+                                <p><strong>Full copy (EXPERIMENTAL)</strong> replicates the original service in the
                                     destination account and harvests all of its associated data.</p>
                             </div>
                         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -272,6 +272,50 @@
                     </div>
                 </div>
             </div>
+            <!-- Deep Copy modal -->
+            <div id="deepCopyModal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deepCopyModalLabel" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
+                            <h3 id="deepCopyModalLabel">Copy information</h3>
+                        </div>
+                        <div class="modal-body">
+                            <form>
+                                <div class="form-horizontal">
+                                    <div class="form-group">
+                                        <div class="col-md-6">
+                                            <label>Copy Type</label>
+                                            <div id="copySelector" class="btn-group" data-toggle="buttons-radio">
+                                                <button type="button" id="btnSimpleCopy" class="btn btn-primary active" data-toggle="button">Simple</button>
+                                                <button type="button" id="btnFullCopy" class="btn btn-default" data-toggle="button">Full</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="form-group has-feedback" style="display:none" id="serviceNameForm">
+                                        <div class="col-md-6">
+                                            <label>Service Name</label>
+                                            <input class="form-control" type="text" value="" id="serviceName">
+                                            <i class="glyphicon form-control-feedback" aria-hidden="true"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </form>
+                            <div class="alert alert-info">
+                                <p><strong>Simple copy</strong> creates a reference to the original service 
+                                    in the destination account.</p>
+                                <p><strong>Full copy</strong> replicates the original service in the
+                                    destination account and harvests all of its associated data.</p>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button class="btn btn-default" data-dismiss="modal" id="btnCancelCopy">Cancel</button>
+                            <button type="submit" class="btn btn-primary disabled" id="btnCopyService">Copy</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
             <!-- Item containers -->
             <div id="itemsContainer" class="row">
                 <div id="itemsArea" class="col-md-5 itemArea">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1037,10 +1037,14 @@ require([
                             var item = jquery.grep(portal.items, function (item, i) {
                                 return (item.id === id);
                             });
+                            var name = description.name;
+                            if (name === null) {
+                                name = description.title;
+                            }
+                            jquery("#serviceName").val(name);
                             item[0].serviceDescription = serviceDescription;
                             jquery("#btnCancelCopy").attr("data-id", description.id);
                             jquery("#btnCopyService").attr("data-id", description.id);
-                            jquery("#serviceName").val(description.name);
                             jquery("#deepCopyModal").modal("show");
                             jquery("#btnCopyService").removeClass("disabled");
                             // Add a listener for the service name form.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -811,6 +811,193 @@ require([
             });
     };
 
+    // Check if the service name is available.
+    var checkServiceName = function (destinationPortal) {
+        var deferred = new jquery.Deferred();
+        var nameInput = jquery("#serviceName");
+        jquery("#serviceName").off("blur"); // Prevent duplicate listeners.
+        nameInput.blur(function (e) {
+            var name = nameInput.val();
+            destinationPortal.self()
+                .then(function (self) {
+                    destinationPortal.checkServiceName(self.user.orgId, name, "Feature Service")
+                        .then(function (available) {
+                            if (available.available !== true) {
+                                var nameError = mustache.to_html(jquery("#serviceNameErrorTemplate").html(), {
+                                    name: name
+                                });
+                                // Prevent appending duplicate error messages.
+                                jquery(".alert-danger.alert-dismissable").remove();
+                                nameInput.parent().parent().after(nameError);
+                                nameInput.parent().addClass("has-error");
+                                nameInput.next().removeClass("glyphicon-ok");
+                            } else {
+                                name = nameInput.val();
+                                jquery(".alert-danger.alert-dismissable").remove();
+                                nameInput.parent().removeClass("has-error");
+                                nameInput.next().addClass("glyphicon-ok");
+                                jquery("#btnCopyService").removeClass("disabled");
+                                deferred.resolve(name);
+                            }
+                        });
+                });
+        });
+        return deferred.promise();
+    };
+
+    /**
+     * simpleCopy() Copies a given item ID.
+     * @id {String} id of the source item
+     * @folder {String} id of the destination folder
+     */
+    var simpleCopy = function (id, folder) {
+        var portalUrl = jquery("#" + id).attr("data-portal");
+        /**
+         * Prevent trying to pass a portal token when
+         * copying content from ArcGIS Online.
+         */
+        if (portalUrl === "https://www.arcgis.com/" &&
+            portalUrl !== app.portals.sourcePortal.portalUrl) {
+            portal = app.portals.arcgisOnline;
+        } else {
+            portal = app.portals.sourcePortal;
+        }
+        var destinationPortal = app.portals.destinationPortal;
+        var item = jquery.grep(portal.items, function (item, i) {
+            return (item.id === id);
+        });
+        var description = item[0].description;
+        var thumbnailUrl = portal.portalUrl + "sharing/rest/content/items/" + id + "/info/" +
+            description.thumbnail + "?token=" + portal.token;
+        portal.itemData(id).always(function (data) {
+            /**
+             * Post it to the destination using always
+             * to ensure that it copies Web Mapping Applications
+             * which don't have a data component and therefore
+             * generate a failed response.
+             */
+            destinationPortal.addItem(destinationPortal.username, folder, description, data, thumbnailUrl).done(function (response) {
+                var html;
+                if (response.success === true) {
+                    // Update the id parameter to reflect the new item's id.
+                    if (description.url.indexOf("id=") > -1) {
+                        var newUrl = description.url.substring(description.url.indexOf("/apps/"));
+                        newUrl = newUrl.replace("id=" + description.id, "id=" + response.id);
+                        var folder = response.folder || "";
+                        destinationPortal.updateUrl(destinationPortal.username, folder, response.id, newUrl)
+                            .done(function (status) {
+                                jquery("#" + id + "_clone").addClass("btn-success");
+                            });
+                    } else {
+                        jquery("#" + id + "_clone").addClass("btn-success");
+                    }
+                } else if (response.error) {
+                    jquery("#" + id + "_clone").addClass("btn-danger");
+                    html = mustache.to_html(jquery("#contentCopyErrorTemplate").html(), {
+                        id: id,
+                        message: response.error.message
+                    });
+                    jquery("#" + id + "_clone").before(html);
+                }
+            }).fail(function (response) {
+                html = mustache.to_html(jquery("#contentCopyErrorTemplate").html(), {
+                    id: id,
+                    message: "Something went wrong."
+                });
+                jquery("#" + id + "_clone").before(html);
+            });
+        });
+    };
+
+    var deepCopyFeatureService = function (id, folder) {
+        var portalUrl = jquery("#" + id).attr("data-portal");
+        /**
+         * Prevent trying to pass a portal token when
+         * copying content from ArcGIS Online.
+         */
+        if (portalUrl === "https://www.arcgis.com/" &&
+            portalUrl !== app.portals.sourcePortal.portalUrl) {
+            portal = app.portals.arcgisOnline;
+        } else {
+            portal = app.portals.sourcePortal;
+        }
+        var destinationPortal = app.portals.destinationPortal;
+        var name = jquery("#serviceName").val();
+        var item = jquery.grep(portal.items, function (item, i) {
+            return (item.id === id);
+        });
+        var description = item[0].description;
+        var serviceDescription = item[0].serviceDescription;
+        var layers = serviceDescription.layers;
+        // Preserve the icon on the cloned button.
+        var span = jquery("#" + id + "_clone > span");
+        jquery("#" + id + "_clone").text(name);
+        jquery("#" + id + "_clone").prepend(span);
+        serviceDescription.name = name;
+        var serviceDefinition = serviceDescription;
+        delete serviceDefinition.layers;
+        destinationPortal.createService(destinationPortal.username, folder, JSON.stringify(serviceDefinition)).then(function (service) {
+            var clone = jquery("#" + id + "_clone");
+            clone.addClass("btn-info");
+            clone.append("<img src='css/grid.svg' class='harvester'/>");
+            clone.attr("data-id", service.itemId);
+            clone.attr("data-portal", destinationPortal.portalUrl);
+            // Update the new item's tags to make it easier to trace its origins.
+            newTags = description.tags;
+            newTags.push("source-" + description.id);
+            destinationPortal.updateDescription(destinationPortal.username, service.itemId, folder, JSON.stringify({
+                tags: newTags
+            }));
+            portal.serviceLayers(description.url)
+                .then(function (definition) {
+                    /*
+                     * Force in the spatial reference.
+                     * Don't know why this is necessary, but if you
+                     * don't then any geometries not in 102100 end up
+                     * on Null Island.
+                     */
+                    jquery.each(definition.layers, function (i, layer) {
+                        layer.adminLayerInfo = {
+                            geometryField: {
+                                name: "Shape",
+                                srid: 102100
+                            }
+                        };
+                    });
+                    destinationPortal.addToServiceDefinition(service.serviceurl, JSON.stringify(definition))
+                        .then(function (response) {
+                            jquery.each(layers, function (i, v) {
+                                var layerId = v.id;
+                                portal.layerRecordCount(description.url, layerId)
+                                    .then(function (records) {
+                                        var offset = 0;
+                                        // Set the count manually in weird cases where maxRecordCount is negative.
+                                        var count = definition.layers[layerId].maxRecordCount < 1 ? 1000 : definition.layers[layerId].maxRecordCount;
+                                        var added = 0;
+                                        var x = 1;
+                                        while (offset <= records.count) {
+                                            x++;
+                                            portal.harvestRecords(description.url, layerId, offset)
+                                                .then(function (serviceData) {
+                                                    destinationPortal.addFeatures(service.serviceurl, layerId, JSON.stringify(serviceData.features))
+                                                        .then(function () {
+                                                            added += count;
+                                                            if (added >= records.count) {
+                                                                jquery("#" + id + "_clone > img").remove();
+                                                                jquery("#" + id + "_clone").removeClass("btn-info");
+                                                                jquery("#" + id + "_clone").addClass("btn-success");
+                                                            }
+                                                        });
+                                                });
+                                            offset += count;
+                                        }
+                                    });
+                            });
+                        });
+                });
+        });
+    };
+
     // Make the drop area accept content items.
     var makeDroppable = function(id) {
 
@@ -839,49 +1026,30 @@ require([
             // Ensure the content type is supported before trying to copy it.
             if (isSupported(type)) {
                 // Get the full item description and data from the source.
-                portal.itemDescription(id).done(function(description) {
-                    var thumbnailUrl = portal.portalUrl +
-                        "sharing/rest/content/items/" + id + "/info/" +
-                        description.thumbnail + "?token=" +
-                        portal.token;
-                    portal.itemData(id).always(function(data) {
-                        /**
-                         * Post it to the destination using always
-                         * to ensure that it copies Web Mapping Applications
-                         * which don't have a data component and therefore
-                         * generate a failed response.
-                         */
-                        destinationPortal.addItem(destinationPortal.username, folder, description, data, thumbnailUrl).done(function(response) {
-                            var html;
-                            if (response.success === true) {
-                                // Update the id parameter to reflect the new item's id.
-                                if (description.url.indexOf("id=") > -1) {
-                                    var newUrl = description.url.substring(description.url.indexOf("/apps/"));
-                                    newUrl = newUrl.replace("id=" + description.id, "id=" + response.id);
-                                    var folder = response.folder || "";
-                                    destinationPortal.updateUrl(destinationPortal.username, folder, response.id, newUrl)
-                                        .done(function() {
-                                            jquery("#" + id + "_clone").addClass("btn-success");
-                                        });
-                                } else {
-                                    jquery("#" + id + "_clone").addClass("btn-success");
-                                }
-                            } else if (response.error) {
-                                jquery("#" + id + "_clone").addClass("btn-danger");
-                                html = mustache.to_html(jquery("#contentCopyErrorTemplate").html(), {
-                                    id: id,
-                                    message: response.error.message
-                                });
-                                jquery("#" + id + "_clone").before(html);
-                            }
-                        }).fail(function() {
-                            html = mustache.to_html(jquery("#contentCopyErrorTemplate").html(), {
-                                id: id,
-                                message: "Something went wrong."
+                portal.itemDescription(id).done(function (description) {
+                    var thumbnailUrl = portal.portalUrl + "sharing/rest/content/items/" + id +
+                        "/info/" + description.thumbnail + "?token=" + portal.token;
+                    portal.cacheItem(description);
+                    switch (type) {
+                    case "Feature Service":
+                        portal.serviceDescription(description.url).done(function (serviceDescription) {
+                            var layers = serviceDescription.layers;
+                            var item = jquery.grep(portal.items, function (item, i) {
+                                return (item.id === id);
                             });
-                            jquery("#" + id + "_clone").before(html);
+                            item[0].serviceDescription = serviceDescription;
+                            jquery("#btnCancelCopy").attr("data-id", description.id);
+                            jquery("#btnCopyService").attr("data-id", description.id);
+                            jquery("#serviceName").val(description.name);
+                            jquery("#deepCopyModal").modal("show");
+                            jquery("#btnCopyService").removeClass("disabled");
+                            // Add a listener for the service name form.
+                            checkServiceName(destinationPortal);
                         });
-                    });
+                        break;
+                    default:
+                        simpleCopy(id, folder);
+                    }
                 });
             } else {
                 // Not supported.
@@ -907,6 +1075,7 @@ require([
 
             // Differentiate this object from the original.
             clone.attr("id", itemId + "_clone");
+            clone.addClass("clone");
 
             // Remove the max-width property so it fills the folder.
             clone.css("max-width", "");
@@ -1544,7 +1713,54 @@ require([
             }
         });
 
-        jquery(document).on("click", "li [data-action]", function(e) {
+        jquery(document).on("click", "#btnSimpleCopy", function () {
+            jquery("#serviceNameForm").hide();
+            jquery(".alert-danger.alert-dismissable").remove();
+            jquery("#btnCopyService").removeClass("disabled");
+            jquery("#btnSimpleCopy").addClass("btn-primary active");
+            jquery("#btnFullCopy").removeClass("btn-primary active");
+            jquery("#btnFullCopy").addClass("btn-default");
+        });
+
+        jquery(document).on("click", "#btnFullCopy", function () {
+            jquery("#serviceNameForm").show();
+            jquery("#btnCopyService").addClass("disabled");
+            jquery("#btnFullCopy").addClass("btn-primary active");
+            jquery("#btnSimpleCopy").removeClass("btn-primary active");
+            jquery("#btnSimpleCopy").addClass("btn-default");
+            jquery("#serviceName").blur();
+        });
+
+        // Add a listener for the future cancel copy button.
+        jquery(document).on("click", "#btnCancelCopy", function (e) {
+            var id = jquery(e.currentTarget).attr("data-id");
+            jquery(".clone[data-id='" + id + "']").remove();
+            jquery("#btnCancelCopy").attr("data-id", "");
+            jquery("#serviceName").attr("value", "");
+            jquery("#btnSimpleCopy").click(); // Reset everything.
+            jquery("#deepCopyModal").modal("hide");
+        });
+
+        // Add a listener for the future copy button.
+        jquery(document).on("click", "#btnCopyService", function (e) {
+            var id = jquery(e.currentTarget).attr("data-id");
+            var folder = jquery(".clone[data-id='" + id + "']").parent().attr("data-folder");
+            var copyType = jquery("#copySelector > .btn-primary").text();
+            switch (copyType) {
+            case "Simple":
+                simpleCopy(id, folder);
+                break;
+            case "Full":
+                deepCopyFeatureService(id, folder);
+                break;
+            }
+            jquery("#btnCancelCopy").attr("data-id", "");
+            jquery("#serviceName").attr("value", "");
+            jquery("#btnSimpleCopy").click(); // Reset everything.
+            jquery("#deepCopyModal").modal("hide");
+        });
+
+        jquery(document).on("click", "li [data-action]", function (e) {
             // Highlight the selected action except for "View My Stats."
             var selectedAction = jquery(e.target).parent().attr("data-action");
             if (selectedAction !== "stats") {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -567,11 +567,13 @@ require([
                     });
 
                     var tables = [];
-                    jquery.each(data.tables, function(table) {
-                        if (data.tables[table].hasOwnProperty("url")) {
-                            tables.push(data.tables[table]);
-                        }
-                    });
+                    if (data.tables) {
+                        jquery.each(data.tables, function(table) {
+                            if (data.tables[table].hasOwnProperty("url")) {
+                                tables.push(data.tables[table]);
+                            }
+                        });
+                    }
 
                     var basemapTitle = data.baseMap.title;
                     var basemapLayers = [];

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -15,10 +15,10 @@ define(["jquery", "portal/util"], function(jquery, util) {
             this.version = function() {
                 if (this.jsonp) {
                     return jquery.ajax({
-                        type: 'GET',
+                        type: "GET",
                         url: this.portalUrl + "sharing/rest?f=json",
                         async: false,
-                        jsonpCallback: 'callback',
+                        jsonpCallback: "callback",
                         crossdomain: true,
                         contentType: "application/json",
                         dataType: "jsonp"
@@ -278,7 +278,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
             /**
              * Get service details.
              */
-            this.serviceDescription = function (url) {
+            this.serviceDescription = function(url) {
                 return jquery.ajax({
                     type: "GET",
                     url: url + "?" + jquery.param({
@@ -294,7 +294,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
             /**
              * Get service details.
              */
-            this.serviceLayers = function (url) {
+            this.serviceLayers = function(url) {
                 return jquery.ajax({
                     type: "GET",
                     url: url + "/layers?" + jquery.param({
@@ -308,15 +308,14 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 });
             };
             /**
-             * 
+             *
              */
-            this.createService = function (username, folder, serviceParameters) {
+            this.createService = function(username, folder, serviceParameters) {
                 return jquery.ajax({
                     type: "POST",
                     url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/createService",
                     data: {
                         createParameters: serviceParameters,
-//                        outputType: "featureService",
                         outputType: "featureService",
                         token: this.token,
                         f: "json"
@@ -328,9 +327,9 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 });
             };
             /**
-             * 
+             *
              */
-            this.addToServiceDefinition = function (serviceUrl, definition) {
+            this.addToServiceDefinition = function(serviceUrl, definition) {
                 serviceUrl = serviceUrl.replace("/rest/services/", "/rest/admin/services/");
                 return jquery.ajax({
                     type: "POST",
@@ -347,9 +346,9 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 });
             };
             /**
-             * 
+             *
              */
-            this.checkServiceName = function (portalId, name, type) {
+            this.checkServiceName = function(portalId, name, type) {
                 return jquery.ajax({
                     type: "GET",
                     url: this.portalUrl + "sharing/rest/portals/" + portalId + "/isServiceNameAvailable?" + jquery.param({
@@ -365,9 +364,9 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 });
             };
             /**
-             * 
+             *
              */
-            this.layerRecordCount = function (serviceUrl, layerId) {
+            this.layerRecordCount = function(serviceUrl, layerId) {
                 return jquery.ajax({
                     type: "GET",
                     url: serviceUrl + "/" + layerId + "/query?" + jquery.param({
@@ -383,9 +382,9 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 });
             };
             /**
-             * 
+             *
              */
-            this.harvestRecords = function (serviceUrl, layerId, offset) {
+            this.harvestRecords = function(serviceUrl, layerId, offset) {
                 return jquery.ajax({
                     type: "GET",
                     url: serviceUrl + "/" + layerId + "/query?" + jquery.param({
@@ -404,9 +403,9 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 });
             };
             /**
-             * 
+             *
              */
-            this.addFeatures = function (serviceUrl, layerId, features) {
+            this.addFeatures = function(serviceUrl, layerId, features) {
                 return jquery.ajax({
                     type: "POST",
                     url: serviceUrl + "/" + layerId + "/addFeatures",
@@ -425,7 +424,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
              * cacheItem() Stores an item with the portal object.
              * @description {Object} the item's description object
              */
-            this.cacheItem = function (description) {
+            this.cacheItem = function(description) {
                 this.items.push({
                     id: description.id,
                     description: description

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -7,6 +7,8 @@ define(["jquery", "portal/util"], function(jquery, util) {
             this.token = config.token;
             this.withCredentials = false;
             this.jsonp = false;
+            this.items = [];
+            this.services = [];
             /**
              * Return the version of the portal.
              */
@@ -230,7 +232,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 postData.f = "json";
                 return jquery.ajax({
                     type: "POST",
-                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update",
                     data: postData,
                     dataType: "json",
                     xhrFields: {
@@ -243,7 +245,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
                 // Update the content in a web map.
                 return jquery.ajax({
                     type: "POST",
-                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update",
                     data: {
                         text: data, // Stringify the Javascript object so it can be properly sent.
                         token: this.token,
@@ -261,7 +263,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
             this.updateUrl = function(username, folder, id, url) {
                 return jquery.ajax({
                     type: "POST",
-                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update?",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/items/" + id + "/update",
                     data: {
                         url: url,
                         token: this.token,
@@ -271,6 +273,162 @@ define(["jquery", "portal/util"], function(jquery, util) {
                     xhrFields: {
                         withCredentials: this.withCredentials
                     }
+                });
+            };
+            /**
+             * Get service details.
+             */
+            this.serviceDescription = function (url) {
+                return jquery.ajax({
+                    type: "GET",
+                    url: url + "?" + jquery.param({
+                        token: this.token,
+                        f: "json"
+                    }),
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * Get service details.
+             */
+            this.serviceLayers = function (url) {
+                return jquery.ajax({
+                    type: "GET",
+                    url: url + "/layers?" + jquery.param({
+                        token: this.token,
+                        f: "json"
+                    }),
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * 
+             */
+            this.createService = function (username, folder, serviceParameters) {
+                return jquery.ajax({
+                    type: "POST",
+                    url: this.portalUrl + "sharing/rest/content/users/" + username + "/" + folder + "/createService",
+                    data: {
+                        createParameters: serviceParameters,
+//                        outputType: "featureService",
+                        outputType: "featureService",
+                        token: this.token,
+                        f: "json"
+                    },
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * 
+             */
+            this.addToServiceDefinition = function (serviceUrl, definition) {
+                serviceUrl = serviceUrl.replace("/rest/services/", "/rest/admin/services/");
+                return jquery.ajax({
+                    type: "POST",
+                    url: serviceUrl + "/addToDefinition",
+                    data: {
+                        addToDefinition: definition,
+                        token: this.token,
+                        f: "json"
+                    },
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * 
+             */
+            this.checkServiceName = function (portalId, name, type) {
+                return jquery.ajax({
+                    type: "GET",
+                    url: this.portalUrl + "sharing/rest/portals/" + portalId + "/isServiceNameAvailable?" + jquery.param({
+                        name: name,
+                        type: type,
+                        token: this.token,
+                        f: "json"
+                    }),
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * 
+             */
+            this.layerRecordCount = function (serviceUrl, layerId) {
+                return jquery.ajax({
+                    type: "GET",
+                    url: serviceUrl + "/" + layerId + "/query?" + jquery.param({
+                        where: "1=1",
+                        returnCountOnly: true,
+                        token: this.token,
+                        f: "json"
+                    }),
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * 
+             */
+            this.harvestRecords = function (serviceUrl, layerId, offset) {
+                return jquery.ajax({
+                    type: "GET",
+                    url: serviceUrl + "/" + layerId + "/query?" + jquery.param({
+                        where: "1=1",
+                        outFields: "*",
+                        returnGeometry: true,
+                        resultOffset: offset,
+                        resultRecordCount: 1000,
+                        token: this.token,
+                        f: "json"
+                    }),
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * 
+             */
+            this.addFeatures = function (serviceUrl, layerId, features) {
+                return jquery.ajax({
+                    type: "POST",
+                    url: serviceUrl + "/" + layerId + "/addFeatures",
+                    data: {
+                        features: features,
+                        token: this.token,
+                        f: "json"
+                    },
+                    dataType: "json",
+                    xhrFields: {
+                        withCredentials: this.withCredentials
+                    }
+                });
+            };
+            /**
+             * cacheItem() Stores an item with the portal object.
+             * @description {Object} the item's description object
+             */
+            this.cacheItem = function (description) {
+                this.items.push({
+                    id: description.id,
+                    description: description
                 });
             };
         }

--- a/src/templates.html
+++ b/src/templates.html
@@ -43,6 +43,15 @@
 
 </script>
 
+<script type="text/template" id="serviceNameErrorTemplate">
+
+    <div class="alert alert-danger alert-dismissable">
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+        <p><strong>{{ name }} is already in use.</strong> Try a different name.</p>
+    </div>
+
+</script>
+
 <script type="text/template" id="searchTemplate">
 
     <form id="searchForm" class="navbar-form navbar-left" role="search">


### PR DESCRIPTION
Heavily requested feature. It works...mostly.

When it fails, it's usually on the `addToDefinition` call and yells about something in the source definition. This is strange, because it happens with the results of some of the ArcGIS Online analytics services. For example, the resulting service from the "Plan Routes" analysis task consistently fail to copy. 

This needs more testing from a broader base so I'm opening it up as "Experimental". This whole app could probably use the "Experimental" tag. :smile: 



Closes #3.