### PR TITLE
fixed mixed content error when copying feature services

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ago-assistant",
   "title": "ArcGIS Online Assistant",
   "description": "A swiss army knife for your ArcGIS Online and Portal for ArcGIS accounts.",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "author": "Evan Caldwell",
   "homepage": "https://github.com/Esri/ago-assistant",
   "repository": {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -960,6 +960,9 @@ require([
             clone.attr("data-id", service.itemId);
             clone.attr("data-portal", destinationPortal.portalUrl);
 
+            // Upgrade the service url to https to prevent mixed content errors.
+            service.serviceurl = portalUtil.upgradeUrl(service.serviceurl);
+
             // Update the new item's tags to make it easier to trace its origins.
             var newTags = description.tags;
             newTags.push("source-" + description.id);
@@ -1063,13 +1066,14 @@ require([
             if (isSupported(type)) {
                 // Get the full item description and data from the source.
                 portal.itemDescription(id).done(function(description) {
-//                    var thumbnailUrl = portal.portalUrl + "sharing/rest/content/items/" + id +
-//                        "/info/" + description.thumbnail + "?token=" + portal.token;
-                    portal.cacheItem(description);
                     switch (type) {
                     case "Feature Service":
+
+                        // Upgrade the service url to https to prevent mixed content errors.
+                        description.url = portalUtil.upgradeUrl(description.url);
+
+                        portal.cacheItem(description);
                         portal.serviceDescription(description.url).done(function(serviceDescription) {
-//                            var layers = serviceDescription.layers;
                             var item = jquery.grep(portal.items, function(item) {
                                 return (item.id === id);
                             });

--- a/src/js/portal/util.js
+++ b/src/js/portal/util.js
@@ -39,6 +39,15 @@ define(["jquery"], function(jquery) {
 
             deferred.resolve(portalUrl);
             return deferred.promise();
+        },
+
+        // Upgrade a URL from http to https.
+        upgradeUrl: function(url) {
+            if (url.indexOf("http://") === 0 && window.location.href.indexOf("https://") === 0) {
+                url = url.replace("http://", "https://");
+            }
+
+            return url;
         }
     };
 });


### PR DESCRIPTION
Copying services with an http endpoint while running the app in https were causing the browser to reject the request due to mixed content.

Added a method to make it easier to upgrade a URL to https when necessary.