### PR TITLE
Fix for #108 login errors with IE 11 on Windows 8.1

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>ArcGIS Online Assistant</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="js/lib/jquery-ui-1.11.4.css"/>
@@ -204,7 +205,7 @@
                                         <div class="form-group">
                                             <div class="col-md-6">
                                                 <div class="btn-group" data-toggle="buttons-radio">
-                                                    <button type="button" id="destinationAgolBtn" class="btn btn-default active" data-toggle="button">ArcGIS Online</button>
+                                                    <button type="button" id="destinationAgolBtn" class="btn btn-default btn-primary active" data-toggle="button">ArcGIS Online</button>
                                                     <button type="button" id="destinationPortalBtn" class="btn btn-default" data-toggle="button">Portal for ArcGIS</button>
                                                 </div>
                                             </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1572,8 +1572,6 @@ require([
         disableEnterKey();
 
         // Preformat the copy login screen.
-        jquery("#destinationAgolBtn").button("toggle");
-        jquery("#destinationAgolBtn").addClass("btn-primary");
         jquery("#destinationUrl").css({
             display: "none"
         });


### PR DESCRIPTION
This is a potential fix for #108 to resolve issue with modal buttons not
being accessible at startup. This caused the login button to not work in
IE 11 on Windows 8.1.