### PR TITLE
Add new functionality for a Webmap map service URL bulk find/replace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dev files
 /node_modules
+/.idea
 
 # Build files
 /build

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -170,3 +170,15 @@ body {
 .webScene {
     background:url(../assets/images/webscene16.png);
 }
+
+.form-group-findreplace {
+    margin-bottom: 0px;
+}
+
+.btn-replace-urls {
+    white-space: normal !important;
+    word-wrap: break-word;
+    font-size: 11px;
+    padding-top: 2px;
+    height: 34px;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -596,6 +596,70 @@ require([
                     // Add the HTML container with the item JSON.
                     jquery("#dropArea").html(html);
 
+                    // Set up Quick Find/Replace
+                    var webmapServices = jquery("[data-original]");
+                    var currentUniqueRootUrlVals = [];
+                    jquery("#origServiceUrlList").empty();
+                    jquery.each(webmapServices, function(service) {
+                        var currentUrl = jquery(webmapServices[service]).val();
+                        var rootOfCurrentUrl = getHostFromURL(currentUrl);
+                        //create unique list of Root URLs for the UI auto-complete dropdown list
+                        //User input also allows freehand strings as well
+                        if (jquery.inArray(rootOfCurrentUrl, currentUniqueRootUrlVals) === -1) {
+                            currentUniqueRootUrlVals.push(rootOfCurrentUrl);
+                            jquery("#origServiceUrlList").append("<option value=" + rootOfCurrentUrl + ">" + rootOfCurrentUrl + "</option>");
+                        }
+                    });
+
+                    //this can be updated later if users want to be able to replace more than
+                    //just the hostname with port section of map service URLs (e.g. the web adaptor name)
+                    function getHostFromURL(href) {
+                        var parsedUrl = href.match(/^(https?\:)\/\/(([^:\/?#]*)(?:\:([0-9]+))?)(\/[^?#]*)(\?[^#]*|)(#.*|)$/);
+                        var protocol = parsedUrl[1];
+                        var hostWithPort = parsedUrl[2];
+                        return protocol + "//" + hostWithPort;
+                    }
+
+                    // Listener for checking user input string for matches in their webmap map service URLs in realtime
+                    jquery("#originalTextUserInput").bind("input", function() {
+                        var origTextUserInput = jquery("#originalTextUserInput").val();
+                        var numFoundStringMatches = 0;
+                        if (origTextUserInput.length > 0) {
+                            var webmapServices = jquery("[data-original]");
+                            jquery.each(webmapServices, function(service) {
+                                var originalUrl = jquery(webmapServices[service]).val();
+                                if (originalUrl.indexOf(origTextUserInput) > -1) {
+                                    numFoundStringMatches += 1;
+                                }
+                            });
+                        }
+                        //check for the case of 1 text match so our English grammar is correct (match vs. matches)
+                        var matchText = (numFoundStringMatches === 1 ? "match" : "matches");
+                        jquery("#stringMatchesFoundText").text("Found " + numFoundStringMatches.toString() + " text " + matchText + " within this webmap's map service URLs (case sensitive).");
+                    });
+
+                    jquery("#bulkUpdateWebmapServiceUrlsBtn").click(function(e) {
+                        var origTextUserInput = jquery("#originalTextUserInput").val();
+                        var newTextUserInput = jquery("#newTextUserInput").val();
+                        //allow a zero length string for the new URL input for the use case of removing
+                        //port designators (e.g. switching from 6080 endpoints to the web adaptor)
+                        if (origTextUserInput.length > 0) {
+                            var webmapServices = jquery("[data-original]");
+                            var foundMatches = 0;
+                            jquery.each(webmapServices, function(service) {
+                                var originalUrl = jquery(webmapServices[service]).val();
+                                if (originalUrl.indexOf(origTextUserInput) > -1) {
+                                    var newCalculatedUrl = originalUrl.replace(origTextUserInput, newTextUserInput);
+                                    jquery(webmapServices[service]).val(newCalculatedUrl);
+                                    foundMatches += 1;
+                                }
+                            });
+                        }
+                        jquery("#originalTextUserInput").val("");
+                        jquery("#newTextUserInput").val("");
+                        jquery("#stringMatchesFoundText").text("");
+                    });
+
                     // Event listener for update button.
                     jquery("#btnUpdateWebmapServices").click(function() {
                         var webmapServices = jquery("[data-original]");

--- a/src/templates.html
+++ b/src/templates.html
@@ -260,6 +260,24 @@
         </div>
         <div class="panel-body" id="itemDescription>
             <form role="form">
+                Quick Text Find/Replace:
+                <div class="row">
+                    <div class="col-xs-4">
+                        <input type="text" id="originalTextUserInput" list="origServiceUrlList" class="form-control" placeholder="Find">
+                        <datalist id="origServiceUrlList">
+                            <!--items are added dynamically based on a calculated unique root URL list-->
+                        </datalist>
+                    </div>
+                    <div class="col-xs-4">
+                        <input type="text" class="form-control" id="newTextUserInput" placeholder="Replace">
+                    </div>
+                    <div class="col-xs-4">
+                        <button id="bulkUpdateWebmapServiceUrlsBtn" class="btn btn-primary btn-replace-urls">Replace Text in URLs Below</button>
+                    </div>
+                    <div class="col-xs-12">
+                        <span id="stringMatchesFoundText" class="small"></span>
+                    </div>
+                </div>
                 <div class="form-group">
                     <h4>Operational Layers</h4>
                     {{ #operationalLayers }}


### PR DESCRIPTION
New functionality was created in reference to issue #37 asking for grep-like ability.

This new functionality will allows users to easily update URL when promoting items from one environment to the next (e.g. dev to stg to test to prod), and also easily swapping out port numbers (e.g. 6080 to 6443 if no web adaptor), and also easily swapping map service URLs from HTTP to HTTPS.

Let me know if anyone has any thoughts on a better place for the new button within the UI. 