### PR TITLE
Fixed Full Copy not getting all records

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1063,14 +1063,16 @@ require([
                                     portal.layerRecordCount(description.url, layerId)
                                         .then(function(records) {
                                             var offset = 0;
-
+                                            console.log("record count >> " + records.count);
                                             // Set the count manually in weird cases where maxRecordCount is negative.
                                             var count = definition.layers[layerId].maxRecordCount < 1 ? 1000 : definition.layers[layerId].maxRecordCount;
+                                            console.log("count >> " + count);
                                             var added = 0;
                                             var x = 1;
                                             while (offset <= records.count) {
+                                                console.log("current offset >> " + offset);
                                                 x++;
-                                                portal.harvestRecords(description.url, layerId, offset)
+                                                portal.harvestRecords(description.url, layerId, offset, count)
                                                     .then(function(serviceData) {
                                                         destinationPortal.addFeatures(service.serviceurl, layerId, JSON.stringify(serviceData.features))
                                                             .then(function() {

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -384,7 +384,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
             /**
              *
              */
-            this.harvestRecords = function(serviceUrl, layerId, offset) {
+            this.harvestRecords = function(serviceUrl, layerId, offset, numresults) {
                 return jquery.ajax({
                     type: "GET",
                     url: serviceUrl + "/" + layerId + "/query?" + jquery.param({
@@ -392,7 +392,7 @@ define(["jquery", "portal/util"], function(jquery, util) {
                         outFields: "*",
                         returnGeometry: true,
                         resultOffset: offset,
-                        resultRecordCount: 1000,
+                        resultRecordCount: numresults,
                         token: this.token,
                         f: "json"
                     }),


### PR DESCRIPTION
The Full Copy had a flaw where if the MaxRecordCount was 2000 for a
Hosted Feature Service, the harvestRecords call had 1000 features hard
coded.  The problem was for every query, you missed 1000 records because
you would say "Offset by 2000, but only give me 1000".  I update the
harvestRecords method for the maxRecordCount to be passed in as a
parameter to fix this issue.