### PR TITLE
Fixes bug in IE11 due to `input` not firing #166

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -349,7 +349,9 @@ require([
                 editButton.tooltip();
                 jsonBackup = codeBlock.text();
                 codeBlock.attr("contentEditable", "true");
-                codeBlock.bind("input", function() {
+                // Check for IE ('Trident') which does not fire an `input` event in anything other than input.
+                var eventType = /Trident/.test(navigator.userAgent) ? "paste cut keyup" : "input";
+                codeBlock.bind(eventType, function() {
                     // Validate the JSON as it is edited.
                     jsonValid = validateJson(codeBlock.text());
                     saveButton.tooltip("destroy");


### PR DESCRIPTION
IE11 does not fire the input event when an element with `contenteditable` set is edited.
This change detects IE (Trident) in the user agent and swaps in `keyup`, `paste` and 
`cut` events instead.