### PR TITLE
Fix for #170 null titles

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1430,8 +1430,14 @@ require([
      */
     var sortArrayAlpha = function(array, key) {
         array.sort(function(a, b) {
-            var titleA = a[key].toUpperCase();
-            var titleB = b[key].toUpperCase();
+            var titleA = null;
+            var titleB = null;
+            if (a[key])  {
+                titleA = a[key].toUpperCase();
+            }
+            if (b[key]) {
+                titleB = b[key].toUpperCase();
+            }
             if (titleA < titleB) {
                 return -1;
             }


### PR DESCRIPTION
Checks to see if the title/object is `null` before trying to sort the titles.

This allows items with `null` titles to be sorted and therefore display properly.