### PR TITLE
portalUr > portalUrl

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1941,7 +1941,7 @@ require([
                 oAuthPopupConfirmation: false
             }).then(function(user) {
                 // If there is no destination or the destination is not the same as ArcGIS Online
-                if (!app.portals.destinationPortal || (app.portals.destinationPortal.portalUrl !== appInfo.portalUr)) {
+                if (!app.portals.destinationPortal || (app.portals.destinationPortal.portalUrl !== appInfo.portalUrl)) {
                     app.portals.destinationPortal = new portalSelf.Portal({
                         portalUrl: user.server + "/",
                         username: user.userId,


### PR DESCRIPTION
progress toward utilizing OAuth2 for authentication exclusively (both SAML cases described in #115 and more generically)

this change makes it possible to configure the app to use OAuth2 to sign into a custom portal _without_ being forced to refresh the page to see content.

```json
    "appId": "6IrLxMbvXIVlSWIL",
    "portalUrl": "https://server.com/gis/"
```

to do:

- [ ] do more testing to make sure i didn't break anything
- [ ] make green sign in dialog more generic and remove the gray one
- [ ] remove the old `generateToken` code
- [ ] ensure that its still possible to transfer content between orgs
- [ ] investigate reading `portalUrl` and `appId` url parameters (to deploy without touching the built source)