### PR TITLE
use portalHostname for all personal accounts - #182

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -203,7 +203,7 @@ require([
                             app.portals.destinationPortal.portalUrl = "https://" + data.urlKey + "." + data.customBaseUrl + "/";
                         } else {
                             // ArcGIS Online personal account.
-                            app.portals.destinationPortal.portalUrl = "https://www.arcgis.com/";
+                            app.portals.destinationPortal.portalUrl = "https://" + data.portalHostname + "/";
                         }
 
                         jquery("#copyModal").modal("hide");


### PR DESCRIPTION
https://www.arcgis.com/sharing/rest/portals/self?f=json returns (similar to my test machine)
```
"isPortal": false,
...
"portalHostname": "www.arcgis.com",
```
so I think this PR should be pretty safe I hope, even though I haven't tested it...