### PR TITLE
Remove ItemId When URL updated

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -721,6 +721,21 @@ require([
                                 .attr("data-original");
                             var newUrl = jquery(webmapServices[service]).val();
 
+                            var webmapObject = JSON.parse(webmapData);
+                            for (var operationalIndex in webmapObject.operationalLayers) {
+                              if (webmapObject.operationalLayers[operationalIndex].url == originalUrl) {
+                                delete webmapObject.operationalLayers[operationalIndex].itemId;
+                              }
+                            }
+
+                            for (var basemapIndex in webmapObject.baseMap.basemapLayers) {
+                              if (webmapObject.baseMap.basemapLayers[basemapIndex].url == originalUrl) {
+                                delete webmapObject.baseMap.basemapLayers[basemapIndex].itemId;
+                              }
+                            }
+
+                            webmapData = JSON.stringify(webmapObject);
+
                             // Find and replace each URL.
                             webmapData = webmapData.replace("\"" + originalUrl + "\"", "\"" + newUrl + "\"");
                             jquery(webmapServices[service]).val(newUrl);


### PR DESCRIPTION
We are finding that with the latest version of the runtime that the discrepancy between the itemId and the item URL may cause the layers to fail to load.  This is to help ensure that when a user modifies their map via the AGO Assistant that they will not run into any issues with failing to load layers due to this discrepancy.  With the current status of ArcGIS Online, if the portal item id cannot be found, it goes to the url as a failover. 