### PR TITLE
Fix so that file based items won't display Data section

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -487,7 +487,7 @@ require([
             jquery(this).removeClass("btn-info");
             portal.itemDescription(id)
                 .then(function(description) {
-                    portal.itemData(id)
+                    portal.itemData(id, description.name)
                         .then(function(data) {
                             if (data) {
                                 itemData = data;

--- a/src/js/portal/content/itemData.js
+++ b/src/js/portal/content/itemData.js
@@ -1,6 +1,17 @@
 import request from "../request";
 
-export function itemData(id) {
+export function itemData(id, name) {
+    // If name is passed as an optional parameter, check to see if it
+    //  contains a period.  This is to handle instances where file based
+    //  items aren't displaying JSON properly, trying to download instead.
+    if ((name !== null) && (name !== undefined)) // should handle null and undefined
+    {
+        if (name.indexOf('.') > -1)
+        {
+            console.info("Skipping /data since name is " + name);
+            return Promise.resolve(null);
+        }
+    }
     let portal = this;
     let url = `${portal.portalUrl}sharing/rest/content/items/${id}/data`;
     let parameters = {


### PR DESCRIPTION
Issue #195 

Looking for comments.  Unfortunately, due to the Sharing API not having an exact property we are interested in, a simple fix to handle potentially 90% of these use cases is to simply look for a period in the name key of the Item JSON, e.g. myroads.shp, myroads.kmz, etc.

Not a great fix, but significantly improves the user experience.  Currently, any file based items just hang.

Yes, my JS if statement could have been significantly reduced, but I don't claim to be a JS expert yet.