### PR TITLE
fix for babelHelpers bug introduced in 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "clean:build": "rimraf build/ && mkdir build",
     "clean:files": "rimraf src/js/main.min* src/js/lib/portal.min*",
     "build:html": "concat-cli -f src/index.html src/templates.html -o build/index.html | cross-env rexreplace \"<package.version>\" $npm_package_version build/index.html",
-    "build:js": "babel src/js/main.js | cross-env rexreplace \"<config.appId>\" $npm_package_config_appId | cross-env rexreplace \"<config.portalUrl>\" $npm_package_config_portalUrl | uglifyjs -c -o build/js/main.min.js",
+    "build:js": "babel src/js/main.js --no-babelrc | cross-env rexreplace \"<config.appId>\" $npm_package_config_appId | cross-env rexreplace \"<config.portalUrl>\" $npm_package_config_portalUrl | uglifyjs -c -o build/js/main.min.js",
     "copy": "copyfiles -u 1 src/oauth-callback.html \"src/assets/**\" \"src/css/**\" \"src/js/lib/**\" build/",
     "lint": "eslint src/js/*.js src/js/portal/*.js",
     "serve": "serve --port 8080 --open ./build"


### PR DESCRIPTION
The config used by rollup when building portal.js tells babel to include the external-helpers library. This was causing console errors for main.js and erratic behavior when using the app. The solution is to ignore `.babelrc` when building `main.js`.