### PR TITLE
fix #207

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "config": {
     "appId": "4E1s0Mv5r0c2l6W8",
-    "portalUrl": "https://www.arcgis.com/"
+    "portalUrl": "https://www.arcgis.com"
   },
   "scripts": {
     "build": "npm run clean:build && npm run copy && npm run rollup && npm run build:html && npm run build:js && npm run clean:files",


### PR DESCRIPTION
The most recent update to ArcGIS Online appears to be less forgiving about extra slashes in the OAuth URI. Previously, the OAuth URI was sending `https://www.arcgis.com//sharing/oauth2/authorize...`. This fix correctly sends  `https://www.arcgis.com/sharing/oauth2/authorize...`

Recommend that we put this on staging for a little while to make sure there aren't any implications on other areas of the app.