### PR TITLE
Add support for dynamic `portalHostName`

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -258,8 +258,8 @@ require([
                 // Set it to the org's custom URL instead of www.arcgis.com.
                 app.portals.sourcePortal.portalUrl = "https://" + data.urlKey + "." + data.customBaseUrl + "/";
             } else {
-                // ArcGIS Online personal account.
-                app.portals.sourcePortal.portalUrl = "https://www.arcgis.com/";
+                // ArcGIS Online personal account (including support for development instances).
+                app.portals.sourcePortal.portalUrl = "https://" + data.portalHostname + "/";
             }
 
             jquery(".nav.navbar-nav").after(html);


### PR DESCRIPTION
Removed hard-coding of "www.arcgis.com" and replaced it with dynamic data for `portalHostName` from REST response.